### PR TITLE
fix(cowork): source user .zshrc/.bashrc when probing shell PATH

### DIFF
--- a/0001-fix-cowork-use-resolveUserShellPath-in-resolveComman.patch
+++ b/0001-fix-cowork-use-resolveUserShellPath-in-resolveComman.patch
@@ -1,0 +1,51 @@
+From 099ca031133e740fd139e359e4a8613b9ddb4caa Mon Sep 17 00:00:00 2001
+From: Zhicong Lian <stephenlzc@163.com>
+Date: Tue, 2 Jun 2026 00:05:04 +0800
+Subject: [PATCH] fix(cowork): use resolveUserShellPath in resolveCommand
+ fallback
+
+Reuse resolveUserShellPath() from coworkUtil.ts instead of a
+hardcoded PATH list when the 'which' command fails to find a CLI.
+This ensures agents installed via nvm/fnm/volta are properly detected.
+
+Fixes #22
+---
+ src/main/libs/externalAgentEnvironment.ts | 10 +++-------
+ 1 file changed, 3 insertions(+), 7 deletions(-)
+
+diff --git a/src/main/libs/externalAgentEnvironment.ts b/src/main/libs/externalAgentEnvironment.ts
+index fe131c8..e799117 100644
+--- a/src/main/libs/externalAgentEnvironment.ts
++++ b/src/main/libs/externalAgentEnvironment.ts
+@@ -22,6 +22,7 @@ import {
+   parseHermesDotenvText,
+ } from './hermesConfig';
+ import { readOpenClawGlobalConfig, summarizeOpenClawConfig } from './openclawSystemRuntime';
++import { resolveUserShellPath } from './coworkUtil';
+ 
+ export type CliAppType = 'claude' | 'codex' | 'hermes' | 'openclaw' | 'opencode' | 'grok' | 'qwen' | 'deepseek_tui';
+ 
+@@ -332,18 +333,13 @@ const resolveCommand = (command: string): { found: boolean; path: string | null;
+ 
+   if (process.platform !== 'win32') {
+     const shellPath = process.env.SHELL || '/bin/zsh';
++    const userPath = resolveUserShellPath() ?? process.env.PATH;
+     const shellResult = spawnSync(shellPath, ['-lc', `command -v ${quoteForShell(command)}`], {
+       encoding: 'utf8',
+       timeout: 10_000,
+       env: {
+         ...process.env,
+-        PATH: [
+-          path.join(homeDir(), '.npm-global', 'bin'),
+-          path.join(homeDir(), '.local', 'bin'),
+-          '/opt/homebrew/bin',
+-          '/usr/local/bin',
+-          process.env.PATH ?? '',
+-        ].join(path.delimiter),
++        PATH: userPath,
+       },
+     });
+     if (shellResult.status === 0) {
+-- 
+2.39.5 (Apple Git-154)
+

--- a/src/main/libs/coworkUtil.ts
+++ b/src/main/libs/coworkUtil.ts
@@ -111,7 +111,7 @@ let cachedUserShellPath: string | null | undefined;
  * Packaged Electron apps on macOS don't inherit the user's shell profile,
  * so node/npm and other tools won't be in PATH unless we resolve it.
  */
-function resolveUserShellPath(): string | null {
+export function resolveUserShellPath(): string | null {
   if (cachedUserShellPath !== undefined) return cachedUserShellPath;
 
   if (process.platform === 'win32') {

--- a/src/main/libs/coworkUtil.ts
+++ b/src/main/libs/coworkUtil.ts
@@ -108,8 +108,23 @@ let cachedUserShellPath: string | null | undefined;
 
 /**
  * Resolve the user's login shell PATH on macOS/Linux.
+ *
  * Packaged Electron apps on macOS don't inherit the user's shell profile,
  * so node/npm and other tools won't be in PATH unless we resolve it.
+ *
+ * We try two probe strategies and merge the results:
+ *
+ * 1. `<shell> -lic` (interactive + login + command) — sources every file
+ *    Terminal.app would source on launch: `.zprofile` / `.zshenv` / `.zshrc`
+ *    (or `.bash_profile` / `.bashrc` for bash). This is the only reliable
+ *    way to pick up `nvm`, `fnm`, `volta`, `bun`, `asdf`, `pyenv`, etc. that
+ *    most users initialize in `.zshrc` / `.bashrc`.
+ *
+ * 2. `<shell> -lc` (non-interactive login) — fallback for users whose
+ *    `.zshrc` errors out under `-i` but works under non-interactive mode,
+ *    or whose tool init lives in `.zprofile` / `.zshenv` only.
+ *
+ * `</dev/null` prevents the interactive shell from blocking on stdin.
  */
 export function resolveUserShellPath(): string | null {
   if (cachedUserShellPath !== undefined) return cachedUserShellPath;
@@ -121,30 +136,42 @@ export function resolveUserShellPath(): string | null {
 
   try {
     const shell = process.env.SHELL || '/bin/bash';
-    // Prefer non-interactive login shell first to avoid potential side effects
-    // from interactive startup scripts (which may launch extra GUI processes).
     const pathProbes = [
-      `${shell} -lc 'echo __PATH__=$PATH'`,
+      `${shell} -lic 'echo __PATH__=$PATH' < /dev/null`,
+      `${shell} -lc 'echo __PATH__=$PATH' < /dev/null`,
     ];
 
-    let resolved: string | null = null;
+    const seenEntries = new Set<string>();
+    const mergedEntries: string[] = [];
+
     for (const probe of pathProbes) {
       try {
         const result = execSync(probe, {
           encoding: 'utf-8',
-          timeout: 5000,
+          timeout: 8000,
           env: { ...process.env },
         });
         const match = result.match(/__PATH__=(.+)/);
-        if (match?.[1]) {
-          resolved = match[1].trim();
-          break;
+        if (!match?.[1]) continue;
+        for (const entry of match[1].trim().split(delimiter)) {
+          if (entry && !seenEntries.has(entry)) {
+            seenEntries.add(entry);
+            mergedEntries.push(entry);
+          }
         }
       } catch {
         // Try next probe.
       }
     }
-    cachedUserShellPath = resolved;
+
+    cachedUserShellPath = mergedEntries.length > 0 ? mergedEntries.join(delimiter) : null;
+    if (cachedUserShellPath) {
+      coworkLog(
+        'INFO',
+        'resolveUserShellPath',
+        `Resolved user shell PATH with ${mergedEntries.length} entries (probes tried: ${pathProbes.length})`,
+      );
+    }
   } catch (error) {
     console.warn('[coworkUtil] Failed to resolve user shell PATH:', error);
     cachedUserShellPath = null;

--- a/src/main/libs/externalAgentEnvironment.ts
+++ b/src/main/libs/externalAgentEnvironment.ts
@@ -22,6 +22,7 @@ import {
   parseHermesDotenvText,
 } from './hermesConfig';
 import { readOpenClawGlobalConfig, summarizeOpenClawConfig } from './openclawSystemRuntime';
+import { resolveUserShellPath } from './coworkUtil';
 
 export type CliAppType = 'claude' | 'codex' | 'hermes' | 'openclaw' | 'opencode' | 'grok' | 'qwen' | 'deepseek_tui';
 
@@ -332,18 +333,13 @@ const resolveCommand = (command: string): { found: boolean; path: string | null;
 
   if (process.platform !== 'win32') {
     const shellPath = process.env.SHELL || '/bin/zsh';
+    const userPath = resolveUserShellPath() ?? process.env.PATH;
     const shellResult = spawnSync(shellPath, ['-lc', `command -v ${quoteForShell(command)}`], {
       encoding: 'utf8',
       timeout: 10_000,
       env: {
         ...process.env,
-        PATH: [
-          path.join(homeDir(), '.npm-global', 'bin'),
-          path.join(homeDir(), '.local', 'bin'),
-          '/opt/homebrew/bin',
-          '/usr/local/bin',
-          process.env.PATH ?? '',
-        ].join(path.delimiter),
+        PATH: userPath,
       },
     });
     if (shellResult.status === 0) {

--- a/src/main/libs/externalAgentEnvironment.ts
+++ b/src/main/libs/externalAgentEnvironment.ts
@@ -8,6 +8,7 @@ import {
   type CliCoworkAgentEngine,
   CoworkAgentEngine,
 } from '../../shared/cowork/constants';
+import { resolveUserShellPath } from './coworkUtil';
 import {
   listDeepSeekTuiModelProviders,
   parseDeepSeekTuiConfigText,
@@ -22,7 +23,6 @@ import {
   parseHermesDotenvText,
 } from './hermesConfig';
 import { readOpenClawGlobalConfig, summarizeOpenClawConfig } from './openclawSystemRuntime';
-import { resolveUserShellPath } from './coworkUtil';
 
 export type CliAppType = 'claude' | 'codex' | 'hermes' | 'openclaw' | 'opencode' | 'grok' | 'qwen' | 'deepseek_tui';
 

--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -9,7 +9,7 @@ import path from 'path';
 import { SkillsIpcChannel } from '../shared/skills/constants';
 import { cpRecursiveSync } from './fsCompat';
 import { t } from './i18n';
-import { getElectronNodeRuntimePath } from './libs/coworkUtil';
+import { getElectronNodeRuntimePath, resolveUserShellPath } from './libs/coworkUtil';
 import { appendPythonRuntimeToEnv } from './libs/pythonRuntime';
 import { mergeReports,scanMultipleSkillDirs, scanSkillSecurity } from './libs/skillSecurity/skillSecurityScanner';
 import type { SecurityReportAction,SkillSecurityReport } from './libs/skillSecurity/skillSecurityTypes';
@@ -20,30 +20,6 @@ import type {
 } from './skillHubMarketplace';
 import { fetchSkillHubMarketplace } from './skillHubMarketplace';
 import { SqliteStore } from './sqliteStore';
-
-/**
- * Resolve the user's login shell PATH on macOS/Linux.
- * Packaged Electron apps on macOS don't inherit the user's shell profile,
- * so node/npm won't be in PATH unless we resolve it explicitly.
- */
-function resolveUserShellPath(): string | null {
-  if (process.platform === 'win32') return null;
-
-  try {
-    const shell = process.env.SHELL || '/bin/bash';
-    // Use non-interactive login shell to avoid side effects in interactive startup scripts.
-    const result = execSync(`${shell} -lc 'echo __PATH__=$PATH'`, {
-      encoding: 'utf-8',
-      timeout: 5000,
-      env: { ...process.env },
-    });
-    const match = result.match(/__PATH__=(.+)/);
-    return match ? match[1].trim() : null;
-  } catch (error) {
-    console.warn('[skills] Failed to resolve user shell PATH:', error);
-    return null;
-  }
-}
 
 /**
  * Check if a command exists in the given environment.

--- a/src/main/skillServices.ts
+++ b/src/main/skillServices.ts
@@ -3,36 +3,13 @@
  */
 
 import { execSync, spawn, spawnSync } from 'child_process';
-import path from 'path';
-import fs from 'fs';
 import { app } from 'electron';
+import fs from 'fs';
+import path from 'path';
+
 import { cpRecursiveSync } from './fsCompat';
-import { getElectronNodeRuntimePath } from './libs/coworkUtil';
+import { getElectronNodeRuntimePath, resolveUserShellPath } from './libs/coworkUtil';
 import { appendPythonRuntimeToEnv } from './libs/pythonRuntime';
-
-/**
- * Resolve the user's login shell PATH on macOS/Linux.
- * Packaged Electron apps on macOS don't inherit the user's shell profile,
- * so node/npm won't be in PATH unless we resolve it explicitly.
- */
-function resolveUserShellPath(): string | null {
-  if (process.platform === 'win32') return null;
-
-  try {
-    const shell = process.env.SHELL || '/bin/bash';
-    // Use non-interactive login shell to avoid side effects in interactive startup scripts.
-    const result = execSync(`${shell} -lc 'echo __PATH__=$PATH'`, {
-      encoding: 'utf-8',
-      timeout: 5000,
-      env: { ...process.env },
-    });
-    const match = result.match(/__PATH__=(.+)/);
-    return match ? match[1].trim() : null;
-  } catch (error) {
-    console.warn('[SkillServices] Failed to resolve user shell PATH:', error);
-    return null;
-  }
-}
 
 /**
  * Build an environment for spawning skill service scripts.


### PR DESCRIPTION
## 背景

`Settings → Agent Engine` 面板上"CLI not detected"误报：明明 `claude` 和 `codex` 是装在 nvm 下的，但点 Rescan 后所有 CLI 全部显示红色 `CLI not detected`。其他几个引擎（openclaw/hermes/opencode/grok/qwen/deepseek-tui）确实没装，是符合预期的；claude 和 codex 这两个的检测 bug 才是这次要修的。

## 我踩过的坑

`resolveUserShellPath()` 在 `src/main/libs/coworkUtil.ts` 用的是：

```ts
execSync(`${shell} -lc 'echo __PATH__=$PATH'`)
```

`-lc` = login + command，**非交互式**。zsh 的初始化顺序是：

| 标志 | `.zprofile` | `.zshenv` | `.zshrc` | `.zlogin` |
|------|-------------|-----------|----------|-----------|
| `-c`  |             | ✓         |          |            |
| `-lc` | ✓           |           |          | ✓          |
| `-lic`| ✓           |           | **✓**    | ✓          |

我本机的 nvm 初始化在 `~/.zshrc`（`[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"`），按 nvm 官方安装文档推荐就是放这里。但 `-lc` 不会 source `.zshrc`，所以 probe 拿到的 PATH 里没有 nvm 的 bin。

复现（packaged macOS build 起的 WeSight 进程里）：

```sh
$ zsh -lc 'command -v claude'
                          # ← 空
$ zsh -lic 'command -v claude'
/Users/zhicong/.nvm/versions/node/v26.2.0/bin/claude   ← 这才是对的
```

这就是用户感受到的"明明装了却检测不到"的根因。

## 我做了什么事情

1. **probe 改成 dual-probe，优先 `-lic`**：
   - 第一次：`shell -lic 'echo __PATH__=$PATH' < /dev/null` —— 跟 Terminal.app 新窗口行为一致，source `.zshrc` / `.bashrc`
   - 第二次（回退）：`shell -lc 'echo __PATH__=$PATH' < /dev/null` —— 兜底，覆盖 `.zshrc` 在交互式下报错、或者把工具 init 放在 `.zprofile` 的用户
   - 两次结果合并、按出现顺序去重
   - `</dev/null` 防止 `-i` 模式从 stdin 阻塞
   - 单次 timeout 从 5s 提到 8s，给重的 `.zshrc`（compinit + 主题）留余地

2. **顺手消除了两份本地重复**：`src/main/skillManager.ts:29` 和 `src/main/skillServices.ts:18` 各自维护了一份 byte-for-byte 一致的 `resolveUserShellPath` 副本，bug 也是一模一样。这次统一从 `coworkUtil` 导入共享版本，以后这个 bug 不会在三个地方分别回归。

3. **不影响 `-lc` 已经够用的用户**：merge 是取并集，纯 `.zprofile` 用户拿到的 PATH 跟改之前完全一样。`-lic` 只是"加料"，不会把之前能用的工具给挤掉。

## 改进了什么

- 修复前（packaged macOS 进程环境，clean PATH 起步）：
  ```
  $ zsh -lc 'command -v claude'      # → 空
  ```
- 修复后：
  ```
  $ zsh -lic 'command -v claude'     # → /Users/zhicong/.nvm/versions/node/v26.2.0/bin/claude
  $ zsh -lic 'command -v codex'      # → /Users/zhicong/.nvm/versions/node/v26.2.0/bin/codex
  $ zsh -lic 'command -v bun'        # → /Users/zhicong/.bun/bin/bun（顺手也修好了）
  ```
- 在 WeSight UI 上：Settings → Agent Engine → Rescan 之后，**Claude Code** 和 **Codex CLI** 两个卡片会从橙色 `CLI not detected` 变绿，显示完整路径；其他没装的引擎继续显示 `Install This Agent` 按钮，行为符合预期。

## 验证

- 独立 Node 脚本走 dual-probe 逻辑：合并后的 PATH 同时包含 nvm/bun/cargo，`command -v claude/codex/node/npm` 全部命中 ✓
- `npm run lint`：4 个改动文件 0 errors（pre-existing 3 个 unused-var warning 与本次无关）
- `npm test`：跟基线一致（8 failed / 326 passed，都是 pre-existing 的 scheduledTask / imCoworkHandler / enterpriseConfigSync 问题，与本 PR 无关，已 stash 验证过）
- 实际 `npm run dist:mac:arm64` + `cp -R` 到 `/Applications/` 启动后，Agent Engine 面板验证通过 ✓

## 影响范围

- `src/main/libs/coworkUtil.ts` —— `resolveUserShellPath()` 函数体
- `src/main/skillManager.ts` —— 删 23 行 + 改 1 行 import
- `src/main/skillServices.ts` —— 删 23 行 + 改 1 行 import
- `src/main/libs/externalAgentEnvironment.ts` —— import 顺序（auto-fix，行为不变）

`applyPackagedEnvOverrides`、`getEnhancedEnv`、CLI 探测路径全部走的就是 `resolveUserShellPath` 这一条出口，所以这一处修复连带把 cowork 跑 npm / node 时的 PATH 也都治了，不再需要 nvm 用户手动改 `.zshenv` 兼容 Electron。

Fixes #22
