### PR TITLE
修复粘贴图片无法被 Agent 读取的问题

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -572,12 +572,13 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
 
   const addImageAttachmentFromDataUrl = useCallback((name: string, dataUrl: string) => {
     // Use the dataUrl as the unique key (no file path for inline images)
-    const pseudoPath = `inline:${name}:${Date.now()}`;
+    const displayName = name.trim() || 'pasted-image.png';
+    const pseudoPath = `inline:${displayName}:${Date.now()}`;
     dispatch(addDraftAttachment({
       draftKey,
       attachment: {
         path: pseudoPath,
-        name,
+        name: displayName,
         isImage: true,
         dataUrl,
       },
@@ -677,10 +678,15 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
             // Fallback: add as regular file attachment
             addAttachment(nativePath);
           } else {
-            // No native path (clipboard/drag from browser) - read via FileReader
+            // No native path (clipboard/drag from browser): stage a real file so agent tools can read it.
             try {
               const dataUrl = await fileToDataUrl(file);
-              addImageAttachmentFromDataUrl(file.name, dataUrl);
+              const stagedPath = await saveInlineFile(file);
+              if (stagedPath) {
+                addAttachment(stagedPath, { isImage: true, dataUrl });
+              } else {
+                addImageAttachmentFromDataUrl(file.name, dataUrl);
+              }
             } catch (error) {
               console.error('Failed to read image from clipboard:', error);
               const stagedPath = await saveInlineFile(file);


### PR DESCRIPTION
## 背景

在任务会话中直接粘贴图片时，图片会以 `inline:` 附件形式保存在输入状态里。提交任务时这类伪路径会被过滤掉，导致 Agent 的工具侧拿不到真实可读的图片文件路径；而用户把图片先放进项目文件夹后，由于附件拥有真实路径，Agent 可以正常读取和使用。

## 修改内容

- 对剪贴板或浏览器拖入、没有本机路径的图片，先通过已有的 `saveInlineFile` 流程暂存为真实文件。
- 将暂存后的真实路径作为图片附件加入输入附件列表，同时保留 `dataUrl`，确保视觉模型仍可接收图片内容。
- 为没有文件名的粘贴图片补充默认名称，避免生成空的 `inline:` 附件名。

## 验证

- `npm run build`
- `npm run lint`（通过；仓库现有 warning 仍存在）