### PR TITLE
fix(cowork): 工具时间线展示 Skill 名称并修复会话结束后状态残留

### DIFF
--- a/src/renderer/components/cowork/CoworkActivitySidebar.tsx
+++ b/src/renderer/components/cowork/CoworkActivitySidebar.tsx
@@ -198,6 +198,11 @@ const ToolRow: React.FC<{ item: CoworkActivityToolItem }> = ({ item }) => (
     <div className="min-w-0 flex-1">
       <div className="flex min-w-0 items-center gap-2">
         <span className="truncate text-xs font-medium text-foreground">{item.toolName}</span>
+        {item.skillName && (
+          <span className="shrink-0 rounded bg-violet-500/10 px-1.5 py-0.5 text-[10px] text-violet-600 dark:text-violet-300">
+            {item.skillName}
+          </span>
+        )}
         <span className="shrink-0 text-[10px] text-muted">
           {i18nService.t(statusLabelKey[item.status])}
         </span>

--- a/src/renderer/utils/coworkActivity.ts
+++ b/src/renderer/utils/coworkActivity.ts
@@ -72,6 +72,7 @@ export interface CoworkActivityToolItem {
   status: ActivityItemStatus;
   timestamp: number;
   filePath: string | null;
+  skillName: string | null;
 }
 
 export interface CoworkActivitySnapshot {
@@ -419,6 +420,11 @@ export function buildCoworkActivitySnapshot(
     }
 
     const filePath = extractPath(input);
+    const isSkillTool = normalized === 'skill';
+    const skillInputId = isSkillTool ? extractString(input, ['skill', 'skillId', 'skill_id', 'name']) : null;
+    const skillName = skillInputId
+      ? (skillById.get(skillInputId)?.name ?? skillInputId)
+      : null;
     toolTimeline.push({
       id: entry.toolUse.id,
       toolName,
@@ -426,11 +432,21 @@ export function buildCoworkActivitySnapshot(
       status,
       timestamp: entry.toolUse.timestamp,
       filePath,
+      skillName,
     });
     fileChanges.push(...buildFileChangeFromTool(entry));
   }
 
-  const activeTool = [...toolTimeline].reverse().find((item) => item.status === ActivityItemStatus.Running) ?? null;
+  const sessionDone = session.status === 'completed' || session.status === 'error';
+  const finalizeTimeline = (items: CoworkActivityToolItem[]): CoworkActivityToolItem[] =>
+    sessionDone
+      ? items.map((item) => item.status === ActivityItemStatus.Running
+        ? { ...item, status: ActivityItemStatus.Completed }
+        : item)
+      : items;
+  const activeTool = sessionDone
+    ? null
+    : ([...toolTimeline].reverse().find((item) => item.status === ActivityItemStatus.Running) ?? null);
   const activitySkills = Array.from(activeSkillIds)
     .map((id) => {
       const skill = skillById.get(id);
@@ -447,6 +463,6 @@ export function buildCoworkActivitySnapshot(
     fileChanges: fileChanges.sort((left, right) => right.timestamp - left.timestamp),
     artifacts: Array.from(artifacts.values()).sort((left, right) => right.timestamp - left.timestamp),
     activeTool,
-    toolTimeline: toolTimeline.slice(-12).reverse(),
+    toolTimeline: finalizeTimeline(toolTimeline.slice(-12).reverse()),
   };
 }

--- a/src/renderer/utils/coworkStudio.test.ts
+++ b/src/renderer/utils/coworkStudio.test.ts
@@ -73,6 +73,7 @@ const makeActivity = (toolName?: string, summary?: string): CoworkActivitySnapsh
       status: ActivityItemStatus.Running,
       timestamp: 11,
       filePath: null,
+      skillName: null,
     }
     : null,
   toolTimeline: [],


### PR DESCRIPTION
## 变更说明

修复 Cowork 活动侧边栏工具时间线的两个问题：

### 1. Skill 名称展示
当工具调用为 Skill 类型时，从工具输入中提取 skill ID 并查找对应的 skill 名称，
在 ToolRow 中以紫色徽章展示。

### 2. 会话结束后状态残留
会话状态为 `completed` 或 `error` 时，工具时间线中仍处于 `Running` 状态的项
自动修正为 `Completed`，同时 `activeTool` 置空，避免会话已结束但工具仍显示"执行中"。

## 变更文件

| 文件 | 变更内容 |
|------|---------|
| `src/renderer/utils/coworkActivity.ts` | 新增 `skillName` 字段，提取 Skill 工具输入中的 skill ID 并解析名称；会话结束时将 Running 状态修正为 Completed |
| `src/renderer/components/cowork/CoworkActivitySidebar.tsx` | ToolRow 组件增加 skill 名称紫色徽章展示 |
| `src/renderer/utils/coworkStudio.test.ts` | 测试 mock 补充 `skillName` 字段 |

## 影响范围

仅影响 Cowork 活动侧边栏的工具时间线展示，不涉及数据流或 IPC 变更。

**效果**
|before|after|
|:-|:-|
|<img width="941" height="537" alt="image" src="https://github.com/user-attachments/assets/0f53f2e7-3799-4a7c-be34-39055ada5023" />|<img width="593" height="500" alt="image" src="https://github.com/user-attachments/assets/4de6013b-a199-4123-8882-459c76b136aa" />|