### PR TITLE
fix(cowork): keep highest-confidence implicit memories per turn

### DIFF
--- a/src/main/libs/coworkMemoryExtractor.test.ts
+++ b/src/main/libs/coworkMemoryExtractor.test.ts
@@ -1,0 +1,46 @@
+import { expect,test } from 'vitest';
+
+import { extractTurnMemoryChanges } from './coworkMemoryExtractor';
+
+const assistantText = '好的，已了解。';
+
+test('keeps the highest-confidence implicit memories when more than the cap qualify', () => {
+  // Order matters: two lower-confidence candidates appear BEFORE the highest one.
+  // preference (0.88) -> ownership (0.9) -> profile (0.93)
+  const userText = '我喜欢深色主题。我养了一只猫。我叫张三。';
+
+  const changes = extractTurnMemoryChanges({
+    userText,
+    assistantText,
+    guardLevel: 'relaxed',
+  });
+
+  const implicitAdds = changes.filter((c) => !c.isExplicit && c.action === 'add');
+
+  // Cap is 2 per turn.
+  expect(implicitAdds).toHaveLength(2);
+
+  // The profile fact (0.93) must survive even though it appears last, and the
+  // lowest-confidence preference (0.88) must be the one dropped.
+  const kept = implicitAdds.map((c) => c.text);
+  expect(kept).toContain('我叫张三');
+  expect(kept).toContain('我养了一只猫');
+  expect(kept).not.toContain('我喜欢深色主题');
+
+  // Sorted by confidence descending.
+  expect(implicitAdds[0].confidence).toBeGreaterThanOrEqual(implicitAdds[1].confidence);
+});
+
+test('deduplicates identical implicit candidates within a single turn', () => {
+  const userText = '我叫张三。我叫张三。';
+
+  const changes = extractTurnMemoryChanges({
+    userText,
+    assistantText,
+    guardLevel: 'relaxed',
+  });
+
+  const implicitAdds = changes.filter((c) => !c.isExplicit && c.action === 'add');
+  expect(implicitAdds).toHaveLength(1);
+  expect(implicitAdds[0].text).toBe('我叫张三');
+});

--- a/src/main/libs/coworkMemoryExtractor.ts
+++ b/src/main/libs/coworkMemoryExtractor.ts
@@ -172,11 +172,15 @@ function extractImplicit(options: ExtractTurnMemoryOptions): ExtractedMemoryChan
       isExplicit: false,
       reason,
     });
-
-    if (result.length >= maxImplicitAdds) break;
   }
 
-  return result;
+  // Keep the highest-confidence candidates rather than the first ones seen, so a
+  // low-value preference appearing early cannot crowd out a high-value profile
+  // fact appearing later in the same turn. Array.prototype.sort is stable, so
+  // candidates that tie on confidence preserve their original order.
+  return result
+    .sort((a, b) => b.confidence - a.confidence)
+    .slice(0, maxImplicitAdds);
 }
 
 export function extractTurnMemoryChanges(options: ExtractTurnMemoryOptions): ExtractedMemoryChange[] {


### PR DESCRIPTION
## 问题

隐式记忆提取每轮最多采纳 2 条。原实现按**句子顺序**依次 push,攒够 2 条就 `break`，于是当一轮命中超过两条候选时，留下来的是**最先出现的**，而不是**置信度最高的**。

结果是：出现在前面的低置信度偏好，会挤掉出现在后面的高置信度身份事实。例如：

> 我喜欢深色主题。我养了一只猫。我叫张三。

旧行为会保留 `我喜欢深色主题`（0.88）+ `我养了一只猫`（0.9），而**丢掉 `我叫张三`（0.93）**，仅仅因为它排在最后。

## 修复

先收集全部合格候选，再按置信度降序排序后取前 N 条。`Array.prototype.sort` 是稳定排序，因此置信度相同的候选会保留原有的句子顺序。单轮去重与「每轮上限 2 条」的行为保持不变。

## 测试

新增同目录的 `coworkMemoryExtractor.test.ts`，覆盖：

1. 排序修复（高置信度的身份事实即使出现在最后也能保留）
2. 单轮内相同候选的去重

`npx vitest run` 通过；`eslint` 无告警。
