### PR TITLE
chore(release): rename version to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "hello@wesight.ai"
   },
   "license": "MIT",
-  "version": "2026.7.28",
+  "version": "1.0.0",
   "openclaw": {
     "version": "v2026.3.2",
     "repo": "https://github.com/openclaw/openclaw.git",


### PR DESCRIPTION
## Summary

- rename the application release version from 2026.7.28 to 1.0.0
- retain all features and Apple signing/notarization changes merged in #62

## Verification

- npm package metadata reports 1.0.0
- git diff --check passes