### PR TITLE
feat(website): download latest release installers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ sandbox/
 **/**/post-commit
 openspec/
 .superpowers/
+.vercel/

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ vercel link --project wesight-portal --scope canghes-projects
 vercel deploy
 ```
 
+Website download buttons use `website/api/download.js` to resolve the matching macOS DMG from the latest public GitHub Release. Keep both `arm64` and `x64` DMG assets attached to each production release.
+
 Keep `.vercel/`, local environment files, `node_modules/`, and `dist/` out of Git. The `website/design-reference/` directory contains source concepts for design reference and is excluded from production static assets.
 
 ### Development With Agent Runtimes

--- a/website/api/download.js
+++ b/website/api/download.js
@@ -1,0 +1,85 @@
+const latestReleaseApiUrl =
+  'https://api.github.com/repos/freestylefly/wesight/releases/latest';
+const releasesUrl = 'https://github.com/freestylefly/wesight/releases/latest';
+
+const architecturePatterns = {
+  arm64: /[._-]mac[._-](arm64|aarch64)\.dmg$/i,
+  x64: /[._-]mac[._-](x64|x86_64|amd64)\.dmg$/i,
+};
+
+function selectInstaller(assets, architecture) {
+  const pattern = architecturePatterns[architecture];
+
+  if (!pattern || !Array.isArray(assets)) {
+    return null;
+  }
+
+  return (
+    assets.find(
+      asset =>
+        typeof asset?.name === 'string' &&
+        pattern.test(asset.name) &&
+        typeof asset?.browser_download_url === 'string' &&
+        asset.browser_download_url.startsWith(
+          'https://github.com/freestylefly/wesight/releases/download/',
+        ),
+    ) ?? null
+  );
+}
+
+function redirect(response, location) {
+  response.statusCode = 302;
+  response.setHeader('Location', location);
+  response.end();
+}
+
+export default async function handler(request, response) {
+  const architecture = Array.isArray(request.query?.arch)
+    ? request.query.arch[0]
+    : request.query?.arch;
+
+  if (!architecturePatterns[architecture]) {
+    redirect(response, releasesUrl);
+    return;
+  }
+
+  response.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=300');
+
+  try {
+    const headers = {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'wesight-download-redirect',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+
+    if (process.env.GITHUB_TOKEN) {
+      headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+    }
+
+    const releaseResponse = await fetch(latestReleaseApiUrl, { headers });
+
+    if (!releaseResponse.ok) {
+      console.warn(
+        `[WebsiteDownload] GitHub release lookup returned HTTP ${releaseResponse.status}.`,
+      );
+      redirect(response, releasesUrl);
+      return;
+    }
+
+    const release = await releaseResponse.json();
+    const installer = selectInstaller(release.assets, architecture);
+
+    if (!installer) {
+      console.warn(
+        `[WebsiteDownload] No ${architecture} DMG was found in the latest release.`,
+      );
+      redirect(response, releasesUrl);
+      return;
+    }
+
+    redirect(response, installer.browser_download_url);
+  } catch (error) {
+    console.error('[WebsiteDownload] GitHub release lookup failed:', error);
+    redirect(response, releasesUrl);
+  }
+}

--- a/website/src/components/DownloadMenu.tsx
+++ b/website/src/components/DownloadMenu.tsx
@@ -1,0 +1,99 @@
+import { Apple, ChevronDown, Cpu, Download } from 'lucide-react';
+import { useEffect, useId, useRef, useState } from 'react';
+
+import { type Copy, releaseUrl } from '../content/siteCopy';
+
+type DownloadMenuProps = {
+  align?: 'start' | 'end';
+  buttonClassName: 'header-cta' | 'primary-button' | 'secondary-button';
+  copy: Copy['downloadMenu'];
+  label: string;
+};
+
+const downloadUrls = {
+  appleSilicon: '/api/download?arch=arm64',
+  intel: '/api/download?arch=x64',
+} as const;
+
+export function DownloadMenu({
+  align = 'start',
+  buttonClassName,
+  copy,
+  label,
+}: DownloadMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuId = useId();
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const closeOnOutsideClick = (event: PointerEvent) => {
+      if (!menuRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('pointerdown', closeOnOutsideClick);
+    document.addEventListener('keydown', closeOnEscape);
+
+    return () => {
+      document.removeEventListener('pointerdown', closeOnOutsideClick);
+      document.removeEventListener('keydown', closeOnEscape);
+    };
+  }, [isOpen]);
+
+  return (
+    <div
+      className={`download-menu download-menu--${align} download-menu--${buttonClassName}`}
+      ref={menuRef}
+    >
+      <button
+        className={buttonClassName}
+        type="button"
+        aria-controls={menuId}
+        aria-expanded={isOpen}
+        aria-haspopup="menu"
+        onClick={() => setIsOpen(current => !current)}
+      >
+        <Download size={buttonClassName === 'header-cta' ? 16 : 18} />
+        <span>{label}</span>
+        <ChevronDown className="download-menu-chevron" size={15} />
+      </button>
+      {isOpen && (
+        <div className="download-menu-panel" id={menuId} role="menu">
+          <div className="download-menu-heading">
+            <strong>{copy.title}</strong>
+            <span>{copy.description}</span>
+          </div>
+          <a href={downloadUrls.appleSilicon} role="menuitem" onClick={() => setIsOpen(false)}>
+            <Apple size={20} />
+            <span>
+              <strong>{copy.appleSilicon}</strong>
+              <small>{copy.appleSiliconHint}</small>
+            </span>
+            <Download size={17} />
+          </a>
+          <a href={downloadUrls.intel} role="menuitem" onClick={() => setIsOpen(false)}>
+            <Cpu size={20} />
+            <span>
+              <strong>{copy.intel}</strong>
+              <small>{copy.intelHint}</small>
+            </span>
+            <Download size={17} />
+          </a>
+          <a className="download-menu-releases" href={releaseUrl} role="menuitem">
+            {copy.allReleases}
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/website/src/components/HomeSections.tsx
+++ b/website/src/components/HomeSections.tsx
@@ -11,7 +11,6 @@ import {
 } from 'lucide-react';
 import { Link } from 'wouter';
 
-import { DownloadMenu } from './DownloadMenu';
 import {
   type Copy,
   docsUrl,
@@ -22,6 +21,7 @@ import {
   releaseUrl,
   repoUrl,
 } from '../content/siteCopy';
+import { DownloadMenu } from './DownloadMenu';
 
 export function Header({
   t,

--- a/website/src/components/HomeSections.tsx
+++ b/website/src/components/HomeSections.tsx
@@ -2,7 +2,6 @@ import {
   Bot,
   Boxes,
   Check,
-  Download,
   FileText,
   Github,
   MessageSquareText,
@@ -12,12 +11,12 @@ import {
 } from 'lucide-react';
 import { Link } from 'wouter';
 
+import { DownloadMenu } from './DownloadMenu';
 import {
   type Copy,
   docsUrl,
   engines,
   heroStats,
-  type Language,
   logoUrl,
   productImages,
   releaseUrl,
@@ -26,11 +25,9 @@ import {
 
 export function Header({
   t,
-  language,
   onToggleLanguage,
 }: {
   t: Copy;
-  language: Language;
   onToggleLanguage: () => void;
 }) {
   return (
@@ -57,14 +54,12 @@ export function Header({
         >
           {t.languageToggle}
         </button>
-        <a
-          className="header-cta"
-          href={releaseUrl}
-          aria-label={language === 'en' ? 'Download WeSight' : '下载 WeSight'}
-        >
-          <Download size={16} />
-          {t.header.download}
-        </a>
+        <DownloadMenu
+          align="end"
+          buttonClassName="header-cta"
+          copy={t.downloadMenu}
+          label={t.header.download}
+        />
       </div>
     </header>
   );
@@ -83,10 +78,11 @@ export function Hero({ t }: { t: Copy }) {
         </h1>
         <p>{t.hero.body}</p>
         <div className="hero-actions">
-          <a className="primary-button" href={releaseUrl}>
-            <Download size={18} />
-            {t.hero.primaryCta}
-          </a>
+          <DownloadMenu
+            buttonClassName="primary-button"
+            copy={t.downloadMenu}
+            label={t.hero.primaryCta}
+          />
           <a className="secondary-button" href={repoUrl}>
             <Github size={18} />
             {t.hero.secondaryCta}
@@ -330,10 +326,12 @@ export function FinalCta({ t }: { t: Copy }) {
           <p>{t.final.body}</p>
         </div>
         <div className="final-actions">
-          <a className="primary-button" href={releaseUrl}>
-            <Download size={18} />
-            {t.final.primaryCta}
-          </a>
+          <DownloadMenu
+            align="end"
+            buttonClassName="primary-button"
+            copy={t.downloadMenu}
+            label={t.final.primaryCta}
+          />
           <a className="secondary-button" href={repoUrl}>
             <Github size={18} />
             {t.final.secondaryCta}

--- a/website/src/components/RoutePage.tsx
+++ b/website/src/components/RoutePage.tsx
@@ -14,7 +14,7 @@ export function RoutePage({ children, language, onToggleLanguage }: RoutePagePro
 
   return (
     <div className="site-shell route-shell">
-      <Header t={t} language={language} onToggleLanguage={onToggleLanguage} />
+      <Header t={t} onToggleLanguage={onToggleLanguage} />
       <main className="route-page">{children}</main>
       <div className="route-footer">
         <SiteFooter t={t} />

--- a/website/src/content/siteCopy.ts
+++ b/website/src/content/siteCopy.ts
@@ -68,6 +68,15 @@ export type Copy = {
     };
     download: string;
   };
+  downloadMenu: {
+    title: string;
+    description: string;
+    appleSilicon: string;
+    appleSiliconHint: string;
+    intel: string;
+    intelHint: string;
+    allReleases: string;
+  };
   hero: {
     title: string[];
     body: string;
@@ -157,6 +166,15 @@ export const copy: Record<Language, Copy> = {
         docs: 'Docs',
       },
       download: 'Download',
+    },
+    downloadMenu: {
+      title: 'Choose your Mac',
+      description: 'Downloads the matching DMG from the latest GitHub Release.',
+      appleSilicon: 'Apple Silicon',
+      appleSiliconHint: 'M1, M2, M3, M4, and newer',
+      intel: 'Intel',
+      intelHint: 'Intel-based Macs',
+      allReleases: 'View all releases',
     },
     hero: {
       title: ['Run your CLI agents', 'from one desktop app'],
@@ -333,6 +351,15 @@ export const copy: Record<Language, Copy> = {
         docs: '文档',
       },
       download: '下载',
+    },
+    downloadMenu: {
+      title: '选择 Mac 版本',
+      description: '从最新 GitHub Release 下载对应的 DMG。',
+      appleSilicon: 'Apple 芯片',
+      appleSiliconHint: 'M1、M2、M3、M4 及更新机型',
+      intel: 'Intel 芯片',
+      intelHint: '搭载 Intel 处理器的 Mac',
+      allReleases: '查看全部发布版本',
     },
     hero: {
       title: ['用一个桌面应用', '运行你的 CLI Agent'],

--- a/website/src/pages/HomePage.tsx
+++ b/website/src/pages/HomePage.tsx
@@ -43,7 +43,7 @@ export function HomePage({ language, onToggleLanguage }: HomePageProps) {
   return (
     <div className="site-shell">
       <PageMeta htmlLang={t.htmlLang} title={t.metaTitle} description={t.metaDescription} />
-      <Header t={t} language={language} onToggleLanguage={onToggleLanguage} />
+      <Header t={t} onToggleLanguage={onToggleLanguage} />
       <main>
         <Hero t={t} />
         <ProductStage t={t} stageNotes={localized.stageNotes} />

--- a/website/src/pages/NotFoundPage.tsx
+++ b/website/src/pages/NotFoundPage.tsx
@@ -1,10 +1,11 @@
-import { ArrowLeft, Download } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import { Link } from 'wouter';
 
+import { DownloadMenu } from '../components/DownloadMenu';
 import { PageMeta } from '../components/PageMeta';
 import { RoutePage } from '../components/RoutePage';
 import { routeCopy } from '../content/routeCopy';
-import { type Language, releaseUrl } from '../content/siteCopy';
+import { copy, type Language } from '../content/siteCopy';
 
 type NotFoundPageProps = {
   language: Language;
@@ -30,10 +31,11 @@ export function NotFoundPage({ language, onToggleLanguage }: NotFoundPageProps) 
             <ArrowLeft size={18} />
             {t.common.backHome}
           </Link>
-          <a className="secondary-button" href={releaseUrl}>
-            <Download size={18} />
-            {t.common.download}
-          </a>
+          <DownloadMenu
+            buttonClassName="secondary-button"
+            copy={copy[language].downloadMenu}
+            label={t.common.download}
+          />
         </div>
       </section>
     </RoutePage>

--- a/website/src/pages/PricingPage.tsx
+++ b/website/src/pages/PricingPage.tsx
@@ -1,10 +1,11 @@
-import { ArrowLeft, Download, KeyRound, Mail, Sparkles } from 'lucide-react';
+import { ArrowLeft, KeyRound, Mail, Sparkles } from 'lucide-react';
 import { Link } from 'wouter';
 
+import { DownloadMenu } from '../components/DownloadMenu';
 import { PageMeta } from '../components/PageMeta';
 import { RoutePage } from '../components/RoutePage';
 import { routeCopy } from '../content/routeCopy';
-import { type Language, releaseUrl } from '../content/siteCopy';
+import { copy, type Language } from '../content/siteCopy';
 
 type PricingPageProps = {
   language: Language;
@@ -30,10 +31,11 @@ export function PricingPage({ language, onToggleLanguage }: PricingPageProps) {
           {t.pricing.status}
         </span>
         <div className="route-actions">
-          <a className="primary-button" href={releaseUrl}>
-            <Download size={18} />
-            {t.common.download}
-          </a>
+          <DownloadMenu
+            buttonClassName="primary-button"
+            copy={copy[language].downloadMenu}
+            label={t.common.download}
+          />
           <a className="secondary-button" href="mailto:hello@wesight.ai">
             <Mail size={18} />
             {t.common.contact}

--- a/website/src/pages/ProfilePage.tsx
+++ b/website/src/pages/ProfilePage.tsx
@@ -1,10 +1,11 @@
-import { ArrowLeft, Download, Laptop, Mail, ShieldCheck } from 'lucide-react';
+import { ArrowLeft, Laptop, Mail, ShieldCheck } from 'lucide-react';
 import { Link } from 'wouter';
 
+import { DownloadMenu } from '../components/DownloadMenu';
 import { PageMeta } from '../components/PageMeta';
 import { RoutePage } from '../components/RoutePage';
 import { routeCopy } from '../content/routeCopy';
-import { type Language, releaseUrl } from '../content/siteCopy';
+import { copy, type Language } from '../content/siteCopy';
 
 type ProfilePageProps = {
   language: Language;
@@ -26,10 +27,11 @@ export function ProfilePage({ language, onToggleLanguage }: ProfilePageProps) {
         <h1>{t.profile.title}</h1>
         <p>{t.profile.body}</p>
         <div className="route-actions">
-          <a className="primary-button" href={releaseUrl}>
-            <Download size={18} />
-            {t.common.download}
-          </a>
+          <DownloadMenu
+            buttonClassName="primary-button"
+            copy={copy[language].downloadMenu}
+            label={t.common.download}
+          />
           <a className="secondary-button" href="mailto:hello@wesight.ai">
             <Mail size={18} />
             {t.common.contact}

--- a/website/src/styles/site.css
+++ b/website/src/styles/site.css
@@ -193,8 +193,10 @@ section,
 
 .header-cta {
   padding: 0 16px;
+  border: 0;
   background: #f4f4f2;
   color: #111317;
+  cursor: pointer;
 }
 
 .language-toggle:hover {
@@ -209,6 +211,7 @@ section,
   background: linear-gradient(180deg, #ffc267, #e98524);
   color: #1c1002;
   box-shadow: 0 16px 44px rgba(247, 146, 44, 0.24);
+  cursor: pointer;
 }
 
 .secondary-button {
@@ -217,6 +220,7 @@ section,
   border: 1px solid var(--line);
   background: rgba(255, 255, 255, 0.06);
   color: var(--text);
+  cursor: pointer;
 }
 
 .header-cta:hover,
@@ -224,6 +228,108 @@ section,
 .primary-button:hover,
 .secondary-button:hover {
   transform: translateY(-1px);
+}
+
+.download-menu {
+  position: relative;
+  display: inline-flex;
+}
+
+.download-menu-chevron {
+  transition: transform 160ms ease;
+}
+
+.download-menu button[aria-expanded='true'] .download-menu-chevron {
+  transform: rotate(180deg);
+}
+
+.download-menu-panel {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  z-index: 60;
+  display: grid;
+  width: min(330px, calc(100vw - 28px));
+  padding: 8px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: rgba(13, 17, 23, 0.98);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.58);
+  color: var(--text);
+  text-align: left;
+  backdrop-filter: blur(20px);
+}
+
+.download-menu--end .download-menu-panel {
+  right: 0;
+  left: auto;
+}
+
+.download-menu-heading {
+  display: grid;
+  gap: 5px;
+  padding: 10px 11px 12px;
+}
+
+.download-menu-heading strong {
+  font-size: 14px;
+}
+
+.download-menu-heading span {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.download-menu-panel > a:not(.download-menu-releases) {
+  display: grid;
+  min-height: 64px;
+  grid-template-columns: 24px minmax(0, 1fr) 20px;
+  gap: 11px;
+  align-items: center;
+  padding: 10px 11px;
+  border-radius: 7px;
+}
+
+.download-menu-panel > a:not(.download-menu-releases):hover {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.download-menu-panel > a:not(.download-menu-releases) > svg:first-child {
+  color: var(--teal);
+}
+
+.download-menu-panel > a:not(.download-menu-releases) > svg:last-child {
+  color: var(--amber);
+}
+
+.download-menu-panel > a span {
+  display: grid;
+  gap: 4px;
+}
+
+.download-menu-panel > a strong {
+  font-size: 14px;
+}
+
+.download-menu-panel > a small {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.download-menu-releases {
+  margin-top: 5px;
+  padding: 11px;
+  border-top: 1px solid var(--line-soft);
+  color: var(--muted-strong);
+  font-size: 12px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.download-menu-releases:hover {
+  color: var(--text);
 }
 
 .hero {
@@ -943,6 +1049,10 @@ section,
     font-size: 0;
   }
 
+  .download-menu--header-cta .download-menu-chevron {
+    display: none;
+  }
+
   .header-actions {
     gap: 8px;
   }
@@ -999,6 +1109,22 @@ section,
   .secondary-button {
     width: 100%;
     min-width: 0;
+  }
+
+  .download-menu {
+    width: 100%;
+  }
+
+  .header-actions .download-menu {
+    width: auto;
+  }
+
+  .download-menu-panel {
+    position: fixed;
+    top: 82px;
+    right: 14px;
+    left: 14px;
+    width: auto;
   }
 
   .hero-meta {


### PR DESCRIPTION
## Summary

- add a reusable bilingual Mac download menu for every primary website CTA
- add a Vercel download redirect that resolves the latest public GitHub Release at request time
- route Apple Silicon and Intel users to the matching DMG while keeping the Releases page as a fallback
- document the release asset contract and ignore root-level Vercel link metadata

## User impact

Visitors can choose their Mac architecture and download the current installer directly. Future release versions do not require hard-coded website URL updates as long as both DMG assets are attached.

## Validation

- `npm run build` in `website/`
- root `npm run lint` (0 errors; existing warnings remain)
- live resolver check against GitHub Release `v1.0.0`
- Vercel Preview: `/`, `/pricing`, `/profile`, SPA fallback, and both download redirects
- Preview deployment: https://wesight-portal-mkyzj02d6-canghes-projects.vercel.app