### PR TITLE
fix(website): add Windows x64 download

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ vercel link --project wesight-portal --scope canghes-projects
 vercel deploy
 ```
 
-Website download buttons use `website/api/download.js` to resolve the matching macOS DMG from the latest public GitHub Release. Keep both `arm64` and `x64` DMG assets attached to each production release.
+Website download buttons use `website/api/download.js` to resolve the matching macOS DMG or Windows x64 EXE from the latest public GitHub Release. Keep the `arm64` and `x64` DMG assets plus `WeSight.Setup.<version>.exe` attached to each production release.
 
 Keep `.vercel/`, local environment files, `node_modules/`, and `dist/` out of Git. The `website/design-reference/` directory contains source concepts for design reference and is excluded from production static assets.
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "website:dev": "npm --prefix website run dev",
     "website:build": "npm --prefix website run build",
     "website:preview": "npm --prefix website run preview",
+    "website:test": "npm --prefix website run test",
     "release:tag": "node scripts/release-tag.cjs",
     "compile:electron": "tsc --project electron-tsconfig.json",
     "precompile:electron": "electron-builder install-app-deps",

--- a/website/api/download.js
+++ b/website/api/download.js
@@ -1,14 +1,50 @@
-const latestReleaseApiUrl =
-  'https://api.github.com/repos/freestylefly/wesight/releases/latest';
+const latestReleaseApiUrl = 'https://api.github.com/repos/freestylefly/wesight/releases/latest';
 const releasesUrl = 'https://github.com/freestylefly/wesight/releases/latest';
 
-const architecturePatterns = {
-  arm64: /[._-]mac[._-](arm64|aarch64)\.dmg$/i,
-  x64: /[._-]mac[._-](x64|x86_64|amd64)\.dmg$/i,
+const installerTargets = {
+  macArm64: {
+    description: 'macOS arm64 DMG',
+    pattern: /[._-]mac[._-](arm64|aarch64)\.dmg$/i,
+  },
+  macX64: {
+    description: 'macOS x64 DMG',
+    pattern: /[._-]mac[._-](x64|x86_64|amd64)\.dmg$/i,
+  },
+  windowsX64: {
+    description: 'Windows x64 installer',
+    pattern: /^WeSight\.Setup\.\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?\.exe$/i,
+  },
 };
 
-function selectInstaller(assets, architecture) {
-  const pattern = architecturePatterns[architecture];
+function readQueryValue(value) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function resolveInstallerTarget(query = {}) {
+  const platform = readQueryValue(query.platform);
+  const architecture = readQueryValue(query.arch);
+
+  if (platform === 'windows') {
+    return !architecture || architecture === 'x64' ? 'windowsX64' : null;
+  }
+
+  if (platform && platform !== 'mac' && platform !== 'macos') {
+    return null;
+  }
+
+  if (architecture === 'arm64') {
+    return 'macArm64';
+  }
+
+  if (architecture === 'x64') {
+    return 'macX64';
+  }
+
+  return null;
+}
+
+export function selectInstaller(assets, target) {
+  const pattern = installerTargets[target]?.pattern;
 
   if (!pattern || !Array.isArray(assets)) {
     return null;
@@ -34,11 +70,9 @@ function redirect(response, location) {
 }
 
 export default async function handler(request, response) {
-  const architecture = Array.isArray(request.query?.arch)
-    ? request.query.arch[0]
-    : request.query?.arch;
+  const target = resolveInstallerTarget(request.query);
 
-  if (!architecturePatterns[architecture]) {
+  if (!target) {
     redirect(response, releasesUrl);
     return;
   }
@@ -67,11 +101,11 @@ export default async function handler(request, response) {
     }
 
     const release = await releaseResponse.json();
-    const installer = selectInstaller(release.assets, architecture);
+    const installer = selectInstaller(release.assets, target);
 
     if (!installer) {
       console.warn(
-        `[WebsiteDownload] No ${architecture} DMG was found in the latest release.`,
+        `[WebsiteDownload] No ${installerTargets[target].description} was found in the latest release.`,
       );
       redirect(response, releasesUrl);
       return;

--- a/website/api/download.test.ts
+++ b/website/api/download.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import handler, { resolveInstallerTarget, selectInstaller } from './download.js';
+
+const trustedReleaseUrl = 'https://github.com/freestylefly/wesight/releases/download/v1.0.1/';
+
+const assets = [
+  {
+    name: 'WeSight.1.0.1.mac.arm64.dmg',
+    browser_download_url: `${trustedReleaseUrl}WeSight.1.0.1.mac.arm64.dmg`,
+  },
+  {
+    name: 'WeSight.1.0.1.mac.x64.dmg',
+    browser_download_url: `${trustedReleaseUrl}WeSight.1.0.1.mac.x64.dmg`,
+  },
+  {
+    name: 'WeSight.Setup.1.0.1.exe.blockmap',
+    browser_download_url: `${trustedReleaseUrl}WeSight.Setup.1.0.1.exe.blockmap`,
+  },
+  {
+    name: 'WeSight.Setup.1.0.1.exe',
+    browser_download_url: `${trustedReleaseUrl}WeSight.Setup.1.0.1.exe`,
+  },
+];
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('resolveInstallerTarget', () => {
+  it('resolves existing macOS download routes', () => {
+    expect(resolveInstallerTarget({ arch: 'arm64' })).toBe('macArm64');
+    expect(resolveInstallerTarget({ arch: ['x64'] })).toBe('macX64');
+  });
+
+  it('resolves Windows x64 with an optional architecture', () => {
+    expect(resolveInstallerTarget({ platform: 'windows' })).toBe('windowsX64');
+    expect(resolveInstallerTarget({ platform: 'windows', arch: 'x64' })).toBe('windowsX64');
+  });
+
+  it('rejects unsupported platform and architecture combinations', () => {
+    expect(resolveInstallerTarget({ platform: 'windows', arch: 'arm64' })).toBeNull();
+    expect(resolveInstallerTarget({ platform: 'linux', arch: 'x64' })).toBeNull();
+    expect(resolveInstallerTarget({})).toBeNull();
+  });
+});
+
+describe('selectInstaller', () => {
+  it('selects the Windows installer without matching its blockmap', () => {
+    expect(selectInstaller(assets, 'windowsX64')?.name).toBe('WeSight.Setup.1.0.1.exe');
+  });
+
+  it('selects both supported macOS installers', () => {
+    expect(selectInstaller(assets, 'macArm64')?.name).toBe('WeSight.1.0.1.mac.arm64.dmg');
+    expect(selectInstaller(assets, 'macX64')?.name).toBe('WeSight.1.0.1.mac.x64.dmg');
+  });
+
+  it('rejects installer URLs outside the WeSight GitHub Releases path', () => {
+    expect(
+      selectInstaller(
+        [
+          {
+            name: 'WeSight.Setup.1.0.1.exe',
+            browser_download_url: 'https://example.com/WeSight.Setup.1.0.1.exe',
+          },
+        ],
+        'windowsX64',
+      ),
+    ).toBeNull();
+  });
+});
+
+it('redirects a Windows request to the latest trusted EXE asset', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ assets }),
+    })),
+  );
+
+  const headers = new Map<string, string>();
+  const response = {
+    statusCode: 0,
+    setHeader(name: string, value: string) {
+      headers.set(name, value);
+    },
+    end() {},
+  };
+
+  await handler({ query: { platform: 'windows', arch: 'x64' } }, response);
+
+  expect(response.statusCode).toBe(302);
+  expect(headers.get('Location')).toBe(`${trustedReleaseUrl}WeSight.Setup.1.0.1.exe`);
+  expect(headers.get('Cache-Control')).toBe('s-maxage=300, stale-while-revalidate=300');
+});

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -18,7 +18,8 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
         "typescript": "^5.9.3",
-        "vite": "^7.2.7"
+        "vite": "^7.2.7",
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1191,6 +1192,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1235,6 +1243,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1282,6 +1308,129 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1352,6 +1501,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1390,6 +1549,13 @@
       "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -1441,6 +1607,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1538,6 +1724,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -1579,6 +1775,27 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1730,6 +1947,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1738,6 +1962,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1755,6 +2010,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -1884,6 +2149,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wouter": {

--- a/website/package.json
+++ b/website/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",
-    "build": "tsc && vite build",
-    "preview": "vite preview --host 127.0.0.1"
+    "build": "npm run test && tsc && vite build",
+    "preview": "vite preview --host 127.0.0.1",
+    "test": "vitest run api/download.test.ts"
   },
   "dependencies": {
     "lucide-react": "^0.554.0",
@@ -19,6 +20,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "typescript": "^5.9.3",
-    "vite": "^7.2.7"
+    "vite": "^7.2.7",
+    "vitest": "^4.1.0"
   }
 }

--- a/website/src/components/DownloadMenu.tsx
+++ b/website/src/components/DownloadMenu.tsx
@@ -1,4 +1,4 @@
-import { Apple, ChevronDown, Cpu, Download } from 'lucide-react';
+import { Apple, ChevronDown, Cpu, Download, MonitorDown } from 'lucide-react';
 import { useEffect, useId, useRef, useState } from 'react';
 
 import { type Copy, releaseUrl } from '../content/siteCopy';
@@ -13,14 +13,10 @@ type DownloadMenuProps = {
 const downloadUrls = {
   appleSilicon: '/api/download?arch=arm64',
   intel: '/api/download?arch=x64',
+  windows: '/api/download?platform=windows&arch=x64',
 } as const;
 
-export function DownloadMenu({
-  align = 'start',
-  buttonClassName,
-  copy,
-  label,
-}: DownloadMenuProps) {
+export function DownloadMenu({ align = 'start', buttonClassName, copy, label }: DownloadMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const menuId = useId();
   const menuRef = useRef<HTMLDivElement>(null);
@@ -86,6 +82,14 @@ export function DownloadMenu({
             <span>
               <strong>{copy.intel}</strong>
               <small>{copy.intelHint}</small>
+            </span>
+            <Download size={17} />
+          </a>
+          <a href={downloadUrls.windows} role="menuitem" onClick={() => setIsOpen(false)}>
+            <MonitorDown size={20} />
+            <span>
+              <strong>{copy.windows}</strong>
+              <small>{copy.windowsHint}</small>
             </span>
             <Download size={17} />
           </a>

--- a/website/src/content/siteCopy.ts
+++ b/website/src/content/siteCopy.ts
@@ -75,6 +75,8 @@ export type Copy = {
     appleSiliconHint: string;
     intel: string;
     intelHint: string;
+    windows: string;
+    windowsHint: string;
     allReleases: string;
   };
   hero: {
@@ -168,12 +170,14 @@ export const copy: Record<Language, Copy> = {
       download: 'Download',
     },
     downloadMenu: {
-      title: 'Choose your Mac',
-      description: 'Downloads the matching DMG from the latest GitHub Release.',
+      title: 'Choose your desktop build',
+      description: 'Downloads the matching installer from the latest GitHub Release.',
       appleSilicon: 'Apple Silicon',
       appleSiliconHint: 'M1, M2, M3, M4, and newer',
       intel: 'Intel',
       intelHint: 'Intel-based Macs',
+      windows: 'Windows x64',
+      windowsHint: '64-bit Windows 10 and 11',
       allReleases: 'View all releases',
     },
     hero: {
@@ -353,12 +357,14 @@ export const copy: Record<Language, Copy> = {
       download: '下载',
     },
     downloadMenu: {
-      title: '选择 Mac 版本',
-      description: '从最新 GitHub Release 下载对应的 DMG。',
+      title: '选择桌面版本',
+      description: '从最新 GitHub Release 下载对应的安装包。',
       appleSilicon: 'Apple 芯片',
       appleSiliconHint: 'M1、M2、M3、M4 及更新机型',
       intel: 'Intel 芯片',
       intelHint: '搭载 Intel 处理器的 Mac',
+      windows: 'Windows x64',
+      windowsHint: '64 位 Windows 10 和 Windows 11',
       allReleases: '查看全部发布版本',
     },
     hero: {


### PR DESCRIPTION
## Summary

- add a bilingual Windows x64 option to every website download menu
- resolve the latest trusted `WeSight.Setup.<version>.exe` asset through the existing Vercel download endpoint
- preserve the existing macOS arm64 and x64 routes
- add Vitest coverage for target resolution, asset selection, trusted URLs, and endpoint redirects

## User impact

Visitors can download the latest Windows x64 installer directly from wesight.ai. The endpoint ignores blockmap metadata and falls back to the GitHub Releases page for unsupported targets.

## Validation

- `npm ci --prefix website`
- `npm run website:build`
- 7 website API tests
- targeted ESLint and Prettier checks
- live GitHub latest-release resolution to `WeSight.Setup.1.0.1.exe`