### PR TITLE
fix(release): validate target macOS native modules

### DIFF
--- a/scripts/verify-mac-artifact.cjs
+++ b/scripts/verify-mac-artifact.cjs
@@ -29,6 +29,8 @@ const PackagedNativePathToken = [
   'win32-x64',
   'arm64-win32',
   'win32-arm64',
+  'ia32-win32',
+  'win32-ia32',
 ];
 
 const rootDir = path.resolve(__dirname, '..');
@@ -43,8 +45,10 @@ function log(message) {
   console.log(`[verify-mac-artifact] ${message}`);
 }
 
-if (!Object.values(MacArtifactTarget).includes(target)) {
-  fail(`Usage: node scripts/verify-mac-artifact.cjs ${MacArtifactTarget.X64}|${MacArtifactTarget.Arm64}`);
+if (require.main === module && !Object.values(MacArtifactTarget).includes(target)) {
+  fail(
+    `Usage: node scripts/verify-mac-artifact.cjs ${MacArtifactTarget.X64}|${MacArtifactTarget.Arm64}`,
+  );
 }
 
 function walk(dir, visitor) {
@@ -72,7 +76,7 @@ function findPackagedApps() {
 }
 
 function runFile(filePath) {
-  const result = runCommand('file', [filePath]);
+  const result = runCommand('file', ['-b', filePath]);
   return (result.stdout || '').trim();
 }
 
@@ -167,9 +171,9 @@ function assertAppleDistributionReady(appPath, expectedArch) {
   log(`Verified Developer ID signing and notarization for ${dmgPath}.`);
 }
 
-function shouldInspectNativeModule(filePath) {
+function shouldInspectNativeModule(filePath, artifactTarget = target) {
   const normalizedPath = filePath.replace(/\\/g, '/');
-  const targetPathTokens = NativeTargetPathToken[target];
+  const targetPathTokens = NativeTargetPathToken[artifactTarget];
   const pathSegments = normalizedPath.split('/');
   const hasTargetToken = (tokens) =>
     tokens.some((token) =>
@@ -188,50 +192,61 @@ function shouldInspectNativeModule(filePath) {
   return !hasTargetToken(PackagedNativePathToken);
 }
 
-const apps = findPackagedApps();
-const expectedArchToken = NativeArchToken[target];
-const appPath = selectApp(apps, expectedArchToken);
-if (!appPath) {
-  fail(`No packaged .app found under ${path.join(rootDir, 'release')}`);
-}
-
-const executablePath = path.join(appPath, 'Contents', 'MacOS', 'WeSight');
-
-log(`Checking ${appPath}`);
-
-if (!fs.existsSync(executablePath)) {
-  fail(`Packaged app executable is missing: ${executablePath}`);
-}
-assertFileHasArch(executablePath, expectedArchToken);
-
-const nativeModules = [];
-const skippedNativeModules = [];
-walk(appPath, (candidate, entry) => {
-  if (!entry.isFile() || !candidate.endsWith('.node')) {
-    return;
+function verifyMacArtifact() {
+  const apps = findPackagedApps();
+  const expectedArchToken = NativeArchToken[target];
+  const appPath = selectApp(apps, expectedArchToken);
+  if (!appPath) {
+    fail(`No packaged .app found under ${path.join(rootDir, 'release')}`);
   }
 
-  if (shouldInspectNativeModule(candidate)) {
-    nativeModules.push(candidate);
-  } else {
-    skippedNativeModules.push(candidate);
+  const executablePath = path.join(appPath, 'Contents', 'MacOS', 'WeSight');
+
+  log(`Checking ${appPath}`);
+
+  if (!fs.existsSync(executablePath)) {
+    fail(`Packaged app executable is missing: ${executablePath}`);
   }
-});
+  assertFileHasArch(executablePath, expectedArchToken);
 
-if (nativeModules.length === 0) {
-  fail('No native .node modules were found in the packaged app.');
+  const nativeModules = [];
+  const skippedNativeModules = [];
+  walk(appPath, (candidate, entry) => {
+    if (!entry.isFile() || !candidate.endsWith('.node')) {
+      return;
+    }
+
+    if (shouldInspectNativeModule(candidate)) {
+      nativeModules.push(candidate);
+    } else {
+      skippedNativeModules.push(candidate);
+    }
+  });
+
+  if (nativeModules.length === 0) {
+    fail('No native .node modules were found in the packaged app.');
+  }
+
+  for (const nativeModule of nativeModules.sort()) {
+    assertFileHasArch(nativeModule, expectedArchToken);
+  }
+
+  log(`Verified ${nativeModules.length} native module(s).`);
+  if (skippedNativeModules.length > 0) {
+    log(`Skipped ${skippedNativeModules.length} non-target vendor native module(s).`);
+  }
+
+  if (process.env.WESIGHT_REQUIRE_APPLE_NOTARIZATION === 'true') {
+    const artifactArch = target === MacArtifactTarget.X64 ? 'x64' : 'arm64';
+    assertAppleDistributionReady(appPath, artifactArch);
+  }
 }
 
-for (const nativeModule of nativeModules.sort()) {
-  assertFileHasArch(nativeModule, expectedArchToken);
+if (require.main === module) {
+  verifyMacArtifact();
 }
 
-log(`Verified ${nativeModules.length} native module(s).`);
-if (skippedNativeModules.length > 0) {
-  log(`Skipped ${skippedNativeModules.length} non-target vendor native module(s).`);
-}
-
-if (process.env.WESIGHT_REQUIRE_APPLE_NOTARIZATION === 'true') {
-  const artifactArch = target === MacArtifactTarget.X64 ? 'x64' : 'arm64';
-  assertAppleDistributionReady(appPath, artifactArch);
-}
+module.exports = {
+  MacArtifactTarget,
+  shouldInspectNativeModule,
+};

--- a/scripts/verify-mac-artifact.test.ts
+++ b/scripts/verify-mac-artifact.test.ts
@@ -1,0 +1,48 @@
+import { createRequire } from 'node:module';
+
+import { describe, expect, test } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { MacArtifactTarget, shouldInspectNativeModule } = require('./verify-mac-artifact.cjs');
+
+describe('macOS native module artifact filtering', () => {
+  test.each([
+    ['@img/sharp-darwin-x64/lib/sharp-darwin-x64.node', MacArtifactTarget.X64],
+    ['vendor/ripgrep/x64-darwin/ripgrep.node', MacArtifactTarget.X64],
+    ['@img/sharp-darwin-arm64/lib/sharp-darwin-arm64.node', MacArtifactTarget.Arm64],
+    ['vendor/ripgrep/arm64-darwin/ripgrep.node', MacArtifactTarget.Arm64],
+  ])('inspects matching target module %s', (modulePath, artifactTarget) => {
+    expect(shouldInspectNativeModule(modulePath, artifactTarget)).toBe(true);
+  });
+
+  test.each([
+    'bufferutil/prebuilds/win32-ia32/bufferutil.node',
+    'bufferutil/prebuilds/win32-x64/bufferutil.node',
+    'utf-8-validate/prebuilds/linux-x64/validation.node',
+    '@img/sharp-darwin-arm64/lib/sharp-darwin-arm64.node',
+  ])('skips non-target x64 module %s', modulePath => {
+    expect(shouldInspectNativeModule(modulePath, MacArtifactTarget.X64)).toBe(false);
+  });
+
+  test.each([
+    'bufferutil/prebuilds/win32-ia32/bufferutil.node',
+    'bufferutil/prebuilds/win32-arm64/bufferutil.node',
+    'utf-8-validate/prebuilds/linux-arm64/validation.node',
+    '@img/sharp-darwin-x64/lib/sharp-darwin-x64.node',
+  ])('skips non-target ARM64 module %s', modulePath => {
+    expect(shouldInspectNativeModule(modulePath, MacArtifactTarget.Arm64)).toBe(false);
+  });
+
+  test.each([
+    [
+      'app.asar.unpacked/node_modules/better-sqlite3/build/Release/better_sqlite3.node',
+      MacArtifactTarget.X64,
+    ],
+    [
+      'app.asar.unpacked/node_modules/better-sqlite3/build/Release/better_sqlite3.node',
+      MacArtifactTarget.Arm64,
+    ],
+  ])('inspects generic module %s', (modulePath, artifactTarget) => {
+    expect(shouldInspectNativeModule(modulePath, artifactTarget)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- make macOS artifact verification read only the binary description from `file -b`, preventing architecture tokens in filesystem paths from satisfying checks
- classify `win32-ia32` and `ia32-win32` prebuilt modules as non-target vendor binaries
- expose the path filter for unit testing and keep CLI verification behavior unchanged
- add ARM64/x64 coverage for matching, non-target, and generic native modules

## Root cause

The v1.0.2 release run built and notarized the Intel DMG, then failed verification because `bufferutil/prebuilds/win32-ia32/bufferutil.node` was treated as a macOS x64 module. The existing ARM64 check could also match `arm64` from the artifact directory path because `file` included the filename in its output.

Failed run: https://github.com/freestylefly/wesight/actions/runs/30379366607

## Validation

- `vitest run scripts/verify-mac-artifact.test.ts scripts/release-version.test.ts scripts/verify-windows-artifact.test.ts` (36 tests)
- fixed verifier against the local ARM64 v1.0.2 candidate: 8 target modules verified and 13 non-target vendor modules skipped
- `git diff --check`

## Release impact

After merge, the unpublished failed `v1.0.2` tag will be recreated on the new `main` commit and the full release workflow will run again.