### PR TITLE
fix(theme): resolve packaged skin assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "hello@wesight.ai"
   },
   "license": "MIT",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "openclaw": {
     "version": "v2026.3.2",
     "repo": "https://github.com/openclaw/openclaw.git",

--- a/src/renderer/components/settings/ThemeSkinSettings.tsx
+++ b/src/renderer/components/settings/ThemeSkinSettings.tsx
@@ -27,6 +27,7 @@ import { getContrastProtectionOpacity } from '@shared/theme/imageAnalysis';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
+import { resolvePublicAssetUrl } from '../../services/publicAssets';
 import { themeService } from '../../services/theme';
 import {
   BUILTIN_THEME_SKINS,
@@ -396,7 +397,11 @@ const ThemeSkinSettings: React.FC<ThemeSkinSettingsProps> = ({ readOnly = false 
           <div className="relative flex min-h-[300px]">
             <div className="hidden w-[168px] shrink-0 border-r border-black/10 bg-surface/60 p-4 backdrop-blur-xl sm:block">
               <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-                <img src="/logo.png" alt="" className="h-6 w-6 rounded-md" />
+                <img
+                  src={resolvePublicAssetUrl('logo.png')}
+                  alt=""
+                  className="h-6 w-6 rounded-md"
+                />
                 WeSight
               </div>
               <div className="mt-5 space-y-2 text-[11px] text-secondary">
@@ -434,7 +439,11 @@ const ThemeSkinSettings: React.FC<ThemeSkinSettingsProps> = ({ readOnly = false 
 
               {previewMode === 'home' ? (
                 <div className="flex flex-1 flex-col items-center justify-center px-8 py-12 text-center">
-                  <img src="/logo.png" alt="" className="h-12 w-12 rounded-xl shadow-lg" />
+                  <img
+                    src={resolvePublicAssetUrl('logo.png')}
+                    alt=""
+                    className="h-12 w-12 rounded-xl shadow-lg"
+                  />
                   <h3 className="mt-3 text-2xl font-semibold text-foreground">
                     {i18nService.t('themeSkinPreviewStart')}
                   </h3>

--- a/src/renderer/services/publicAssets.test.ts
+++ b/src/renderer/services/publicAssets.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'vitest';
+
+import { resolvePublicAssetUrl } from './publicAssets';
+
+test('resolves packaged public assets relative to the renderer document', () => {
+  const packagedRendererUrl =
+    'file:///Applications/WeSight.app/Contents/Resources/app.asar/dist/index.html';
+
+  expect(resolvePublicAssetUrl(
+    '/theme-skins/cloudridge-dawn.webp',
+    packagedRendererUrl,
+  )).toBe(
+    'file:///Applications/WeSight.app/Contents/Resources/app.asar/dist/theme-skins/cloudridge-dawn.webp',
+  );
+  expect(resolvePublicAssetUrl('/logo.png', packagedRendererUrl))
+    .toBe('file:///Applications/WeSight.app/Contents/Resources/app.asar/dist/logo.png');
+});
+
+test('keeps development and hosted base paths intact', () => {
+  expect(resolvePublicAssetUrl('logo.png', 'http://localhost:5175/'))
+    .toBe('http://localhost:5175/logo.png');
+  expect(resolvePublicAssetUrl(
+    '/theme-skins/cloudridge-dawn.webp',
+    'https://example.com/wesight/',
+  )).toBe('https://example.com/wesight/theme-skins/cloudridge-dawn.webp');
+});

--- a/src/renderer/services/publicAssets.ts
+++ b/src/renderer/services/publicAssets.ts
@@ -1,0 +1,16 @@
+const normalizeBaseUrl = (baseUrl: string): string =>
+  baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+
+export const resolvePublicAssetUrl = (
+  assetPath: string,
+  baseUrl = typeof document === 'undefined'
+    ? import.meta.env.BASE_URL
+    : document.baseURI,
+): string => {
+  const normalizedAssetPath = assetPath.replace(/^\/+/, '');
+  try {
+    return new URL(normalizedAssetPath, baseUrl).href;
+  } catch {
+    return `${normalizeBaseUrl(baseUrl)}${normalizedAssetPath}`;
+  }
+};

--- a/src/renderer/theme/skin/builtins.ts
+++ b/src/renderer/theme/skin/builtins.ts
@@ -8,6 +8,8 @@ import {
   type ThemeSkinComposition,
 } from '@shared/theme/constants';
 
+import { resolvePublicAssetUrl } from '../../services/publicAssets';
+
 export interface BuiltinThemeSkin {
   id: string;
   nameKey: string;
@@ -77,7 +79,7 @@ const createComposition = (
 
 const cloudridgeAsset = createBuiltinAsset(
   BuiltinThemeSkinId.CloudridgeDawn,
-  '/theme-skins/cloudridge-dawn.webp',
+  resolvePublicAssetUrl('theme-skins/cloudridge-dawn.webp'),
   '#b77949',
   '#d6a46a',
   0.67,
@@ -86,7 +88,7 @@ const cloudridgeAsset = createBuiltinAsset(
 
 const midnightAsset = createBuiltinAsset(
   BuiltinThemeSkinId.MidnightHorizon,
-  '/theme-skins/midnight-horizon.webp',
+  resolvePublicAssetUrl('theme-skins/midnight-horizon.webp'),
   '#315f9f',
   '#3da6b8',
   0.12,
@@ -95,7 +97,7 @@ const midnightAsset = createBuiltinAsset(
 
 const paperAsset = createBuiltinAsset(
   BuiltinThemeSkinId.QuietPaperGarden,
-  '/theme-skins/quiet-paper-garden.webp',
+  resolvePublicAssetUrl('theme-skins/quiet-paper-garden.webp'),
   '#8b9b83',
   '#b68b5a',
   0.88,


### PR DESCRIPTION
## Summary

- resolve packaged public theme assets against Electron's document base URI
- fix the settings preview logo and all three bundled skin backgrounds in `file://` production builds
- bump the application version to `1.0.3` for the corrective installer release

## Root cause

Root-relative URLs such as `/theme-skins/...` and `/logo.png` resolve from the filesystem root when the packaged Electron renderer is loaded through `file://`, leaving bundled images unavailable on a newly installed machine.

## User impact

Fresh installations can display the built-in skin images, the theme preview logo, and imported custom skins correctly even when the original imported image has moved or been deleted.

## Validation

- `npm test`: 73 files, 533 tests passed
- `npm run lint`: 0 errors (365 existing warnings)
- `NODE_ENV=production npm run build`: passed
- packaged production output verified to contain the three skin assets and use `document.baseURI`
- production-mode runtime verified for the logo, home background, all three bundled skins, and a custom skin
- `git diff --check`: passed