### PR TITLE
feat(release): add Chinese changelog pipeline

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -153,6 +153,8 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
@@ -186,20 +188,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          gh api \
-            --method POST \
-            "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
-            -f tag_name="$TAG_NAME" \
-            --jq .body > generated-notes.md
-
-          {
-            cat <<'EOF'
-          > [!WARNING]
-          > The Windows x64 installer is currently unsigned. Microsoft Defender SmartScreen may show an unrecognized app warning during installation.
-
-          EOF
-            cat generated-notes.md
-          } > release-notes.md
+          node scripts/render-release-notes.cjs "$TAG_NAME" release-notes.md
 
           release_args=(
             --repo "$GITHUB_REPOSITORY"

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "website:build": "npm --prefix website run build",
     "website:preview": "npm --prefix website run preview",
     "website:test": "npm --prefix website run test",
+    "release:notes": "node scripts/render-release-notes.cjs",
     "release:tag": "node scripts/release-tag.cjs",
     "compile:electron": "tsc --project electron-tsconfig.json",
     "precompile:electron": "electron-builder install-app-deps",

--- a/scripts/release-tag.cjs
+++ b/scripts/release-tag.cjs
@@ -3,6 +3,7 @@
 
 const { spawnSync } = require('child_process');
 
+const { getReleaseNotesEntry, readReleaseNotes } = require('./render-release-notes.cjs');
 const { parseReleaseVersion, readPackageVersion } = require('./release-version.cjs');
 
 function parseArguments(args) {
@@ -59,6 +60,8 @@ function runReleaseTag({
       `Requested version ${metadata.version} does not match package.json version ${normalizedPackageVersion}.`,
     );
   }
+
+  getReleaseNotesEntry(metadata.version, readReleaseNotes(projectRoot));
 
   const branch = git(['branch', '--show-current']).stdout.trim();
   if (branch !== 'main') {

--- a/scripts/release-version.test.ts
+++ b/scripts/release-version.test.ts
@@ -151,6 +151,17 @@ describe('release tag command', () => {
     ).toThrow('does not match package.json version 1.0.1');
   });
 
+  test('rejects a release without prepared Chinese notes', () => {
+    const { git } = createGit();
+    expect(() =>
+      runReleaseTag({
+        requestedVersion: '9.9.9',
+        packageVersion: '9.9.9',
+        git,
+      }),
+    ).toThrow('No Chinese release notes found for v9.9.9');
+  });
+
   test('rejects a dirty working tree', () => {
     const { git } = createGit({ dirty: true });
     expect(() =>

--- a/scripts/render-release-notes.cjs
+++ b/scripts/render-release-notes.cjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const RELEASE_NOTES_PATH = path.join(
+  'website',
+  'src',
+  'content',
+  'releaseNotes.json',
+);
+
+function normalizeVersion(version) {
+  return typeof version === 'string' ? version.trim().replace(/^v/i, '') : '';
+}
+
+function readReleaseNotes(projectRoot = path.resolve(__dirname, '..')) {
+  const releaseNotesPath = path.join(projectRoot, RELEASE_NOTES_PATH);
+  const document = JSON.parse(fs.readFileSync(releaseNotesPath, 'utf8'));
+
+  if (document.schemaVersion !== 1 || !Array.isArray(document.releases)) {
+    throw new Error('Release notes must use schema version 1 and include a releases array.');
+  }
+
+  return document;
+}
+
+function getReleaseNotesEntry(version, document = readReleaseNotes()) {
+  const normalizedVersion = normalizeVersion(version);
+  const release = document.releases.find(entry => entry.version === normalizedVersion);
+
+  if (!release) {
+    throw new Error(
+      `No Chinese release notes found for v${normalizedVersion || '<empty>'}. Add the version to ${RELEASE_NOTES_PATH} before publishing.`,
+    );
+  }
+
+  if (
+    !release.title ||
+    !release.summary ||
+    !release.date ||
+    !release.compareUrl ||
+    !release.releaseUrl ||
+    !Array.isArray(release.sections) ||
+    release.sections.length === 0
+  ) {
+    throw new Error(`Chinese release notes for v${normalizedVersion} are incomplete.`);
+  }
+
+  for (const section of release.sections) {
+    if (!section.title || !Array.isArray(section.items) || section.items.length === 0) {
+      throw new Error(`Chinese release notes for v${normalizedVersion} contain an empty section.`);
+    }
+
+    if (section.items.some(item => !item.text || !Array.isArray(item.areas) || item.areas.length === 0)) {
+      throw new Error(`Chinese release notes for v${normalizedVersion} contain an invalid item.`);
+    }
+  }
+
+  return release;
+}
+
+function renderReleaseNotes(version, document = readReleaseNotes()) {
+  const release = getReleaseNotesEntry(version, document);
+  const lines = [
+    '> [!WARNING]',
+    `> ${document.windowsUnsignedNotice}`,
+    '',
+    `## WeSight v${release.version} · ${release.title}`,
+    '',
+    release.summary,
+    '',
+  ];
+
+  for (const section of release.sections) {
+    lines.push(`### ${section.title}`, '');
+    for (const item of section.items) {
+      lines.push(`- ${item.text}`);
+    }
+    lines.push('');
+  }
+
+  lines.push(`[查看 v${release.version} 的完整代码差异](${release.compareUrl})`, '');
+  return lines.join('\n');
+}
+
+function main(args = process.argv.slice(2)) {
+  if (args.length < 1 || args.length > 2) {
+    throw new Error('Usage: node scripts/render-release-notes.cjs <version> [output-file]');
+  }
+
+  const output = renderReleaseNotes(args[0]);
+  if (args[1]) {
+    fs.writeFileSync(path.resolve(args[1]), output, 'utf8');
+    return;
+  }
+
+  process.stdout.write(output);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`[ReleaseNotes] rendering failed: ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  getReleaseNotesEntry,
+  main,
+  normalizeVersion,
+  readReleaseNotes,
+  renderReleaseNotes,
+};

--- a/scripts/render-release-notes.test.ts
+++ b/scripts/render-release-notes.test.ts
@@ -1,0 +1,35 @@
+import { createRequire } from 'node:module';
+
+import { describe, expect, test } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const {
+  getReleaseNotesEntry,
+  normalizeVersion,
+  readReleaseNotes,
+  renderReleaseNotes,
+} = require('./render-release-notes.cjs');
+
+describe('Chinese release notes', () => {
+  test('normalizes version tags', () => {
+    expect(normalizeVersion('v1.0.3')).toBe('1.0.3');
+  });
+
+  test('renders the current release in Chinese Markdown', () => {
+    const markdown = renderReleaseNotes('1.0.3');
+
+    expect(markdown).toContain('## WeSight v1.0.3 · 主题资源修复');
+    expect(markdown).toContain('### 修复');
+    expect(markdown).toContain('Windows x64 安装包当前尚未签名');
+    expect(markdown).toContain(
+      '[查看 v1.0.3 的完整代码差异](https://github.com/freestylefly/wesight/compare/v1.0.2...v1.0.3)',
+    );
+    expect(markdown).not.toContain("What's Changed");
+  });
+
+  test('rejects a version without prepared release notes', () => {
+    expect(() => getReleaseNotesEntry('9.9.9', readReleaseNotes())).toThrow(
+      'No Chinese release notes found for v9.9.9',
+    );
+  });
+});

--- a/src/renderer/components/update/AppUpdateModal.tsx
+++ b/src/renderer/components/update/AppUpdateModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import type { AppUpdateDownloadProgress,AppUpdateInfo } from '../../services/appUpdate';
+import type { AppUpdateDownloadProgress, AppUpdateInfo } from '../../services/appUpdate';
 import { i18nService } from '../../services/i18n';
 import Modal from '../common/Modal';
 
@@ -40,7 +40,7 @@ const AppUpdateModal: React.FC<AppUpdateModalProps> = ({
 }) => {
   const { latestVersion, date, changeLog } = updateInfo;
   const lang = i18nService.getLanguage();
-  const currentLog = changeLog?.[lang] ?? { title: '', content: [] };
+  const currentLog = changeLog?.[lang] ?? { title: '', summary: '', content: [] };
   const isDismissible = modalState === 'info' || modalState === 'error';
 
   return (
@@ -59,6 +59,12 @@ const AppUpdateModal: React.FC<AppUpdateModalProps> = ({
               {currentLog.title && (
                 <p className="mt-3 text-sm font-medium text-foreground">
                   {currentLog.title}
+                </p>
+              )}
+
+              {currentLog.summary && (
+                <p className="mt-1.5 text-sm leading-6 text-secondary">
+                  {currentLog.summary}
                 </p>
               )}
 

--- a/src/renderer/services/appUpdate.test.ts
+++ b/src/renderer/services/appUpdate.test.ts
@@ -105,3 +105,57 @@ test('checkForAppUpdate ignores releases without a WeSight installer asset', asy
 
   await expect(checkForAppUpdate('2026.6.1')).resolves.toBeNull();
 });
+
+test('checkForAppUpdate converts Chinese GitHub Markdown into clean client release notes', async () => {
+  const fetchMock = window.electron.api.fetch as ReturnType<typeof vi.fn>;
+  fetchMock.mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    data: {
+      tag_name: 'v1.0.4',
+      name: 'v1.0.4',
+      published_at: '2026-07-30T00:00:00Z',
+      body: [
+        '> [!WARNING]',
+        '> Windows x64 安装包当前尚未签名。',
+        '',
+        '## WeSight v1.0.4 · 更新体验优化',
+        '',
+        '本次更新让版本信息更清晰。',
+        '',
+        '### 优化',
+        '',
+        '- 官网、GitHub Release 与客户端统一使用中文更新日志',
+        '- 清理客户端中的 Markdown 标记',
+        '',
+        '[查看 v1.0.4 的完整代码差异](https://github.com/freestylefly/wesight/compare/v1.0.3...v1.0.4)',
+      ].join('\n'),
+      assets: [
+        {
+          name: 'WeSight.Setup.1.0.4.exe',
+          browser_download_url: 'https://example.com/WeSight.Setup.1.0.4.exe',
+        },
+      ],
+    },
+  });
+
+  await expect(checkForAppUpdate('1.0.3')).resolves.toMatchObject({
+    latestVersion: '1.0.4',
+    changeLog: {
+      zh: {
+        title: '更新体验优化',
+        summary: '本次更新让版本信息更清晰。',
+        content: [
+          '官网、GitHub Release 与客户端统一使用中文更新日志',
+          '清理客户端中的 Markdown 标记',
+        ],
+      },
+      en: {
+        title: '更新体验优化',
+        summary: '本次更新让版本信息更清晰。',
+      },
+    },
+  });
+});

--- a/src/renderer/services/appUpdate.ts
+++ b/src/renderer/services/appUpdate.ts
@@ -42,7 +42,11 @@ type GitHubReleaseResponse = {
   assets?: GitHubReleaseAsset[];
 };
 
-export type ChangeLogEntry = { title: string; content: string[] };
+export type ChangeLogEntry = {
+  title: string;
+  summary: string;
+  content: string[];
+};
 
 export interface AppUpdateDownloadProgress {
   received: number;
@@ -100,6 +104,74 @@ const isNewerVersion = (latestVersion: string, currentVersion: string): boolean 
   compareVersions(latestVersion, currentVersion) > 0
 );
 
+const stripInlineMarkdown = (value: string): string => (
+  value
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[*_`~]/g, '')
+    .trim()
+);
+
+const isGenericReleaseHeading = (value: string): boolean => (
+  /^(?:what'?s changed|更新内容|更新日志)$/i.test(value.trim())
+);
+
+export const parseGitHubReleaseNotes = (
+  body: string | undefined,
+  fallbackTitle: string,
+): ChangeLogEntry => {
+  let title = fallbackTitle;
+  let summary = '';
+  const content: string[] = [];
+
+  for (const rawLine of (body || '').split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('>') || /^<!--/.test(line)) {
+      continue;
+    }
+
+    const headingMatch = line.match(/^##\s+(.+)$/);
+    if (headingMatch) {
+      const heading = stripInlineMarkdown(headingMatch[1]);
+      if (!isGenericReleaseHeading(heading)) {
+        title = heading.replace(/^WeSight\s+v?[\w.+-]+\s*[·:：-]\s*/i, '').trim() || title;
+      }
+      continue;
+    }
+
+    if (/^###\s+/.test(line)) {
+      continue;
+    }
+
+    const listItemMatch = line.match(/^[-*]\s+(.+)$/);
+    if (listItemMatch) {
+      const item = stripInlineMarkdown(listItemMatch[1])
+        .replace(/\s+by\s+@\S+.*$/i, '')
+        .trim();
+      if (item) {
+        content.push(item);
+      }
+      continue;
+    }
+
+    if (
+      /完整(?:代码)?差异|完整更新对比|full changelog/i.test(line) ||
+      /^\[[^\]]+\]\(https:\/\/github\.com\/[^)]+\/compare\//i.test(line)
+    ) {
+      continue;
+    }
+
+    if (!summary) {
+      summary = stripInlineMarkdown(line);
+    }
+  }
+
+  return {
+    title,
+    summary,
+    content: content.slice(0, 12),
+  };
+};
+
 type UpdateValue = NonNullable<NonNullable<UpdateApiResponse['data']>['value']>;
 
 const getPlatformDownloadUrl = (value: UpdateValue | undefined): string | null => {
@@ -152,14 +224,9 @@ const parseGitHubReleaseUpdate = (
     return null;
   }
 
-  const bodyLines = (payload.body || '')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line && !/^#+\s*/.test(line))
-    .slice(0, 12);
-  const title = payload.name?.trim() || payload.tag_name?.trim() || latestVersion;
+  const fallbackTitle = payload.name?.trim() || payload.tag_name?.trim() || latestVersion;
   const date = payload.published_at?.slice(0, 10) || '';
-  const entry = { title, content: bodyLines };
+  const entry = parseGitHubReleaseNotes(payload.body, fallbackTitle);
   const downloadUrl = getGitHubDownloadUrl(payload);
   if (!downloadUrl) {
     console.warn(`[AppUpdate] release ${latestVersion} has no valid WeSight installer for ${window.electron.platform}/${window.electron.arch}`);
@@ -224,6 +291,7 @@ export const checkForAppUpdate = async (currentVersion: string, manual?: boolean
 
   const toEntry = (log?: ChangeLogLang): ChangeLogEntry => ({
     title: typeof log?.title === 'string' ? log.title : '',
+    summary: '',
     content: Array.isArray(log?.content) ? log.content : [],
   });
 

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Route, Router, Switch } from 'wouter';
 
 import { type Language } from './content/siteCopy';
+import { ChangelogPage } from './pages/ChangelogPage';
 import { HomePage } from './pages/HomePage';
 import { NotFoundPage } from './pages/NotFoundPage';
 import { PricingPage } from './pages/PricingPage';
@@ -21,6 +22,9 @@ export function App() {
         </Route>
         <Route path="/pricing">
           <PricingPage language={language} onToggleLanguage={onToggleLanguage} />
+        </Route>
+        <Route path="/changelog">
+          <ChangelogPage language={language} onToggleLanguage={onToggleLanguage} />
         </Route>
         <Route path="/profile">
           <ProfilePage language={language} onToggleLanguage={onToggleLanguage} />

--- a/website/src/components/HomeSections.tsx
+++ b/website/src/components/HomeSections.tsx
@@ -18,7 +18,6 @@ import {
   heroStats,
   logoUrl,
   productImages,
-  releaseUrl,
   repoUrl,
 } from '../content/siteCopy';
 import { DownloadMenu } from './DownloadMenu';
@@ -43,6 +42,7 @@ export function Header({
         <a href="/#engines">{t.header.nav.engines}</a>
         <a href="/#skills">{t.header.nav.skills}</a>
         <a href="/#open-source">{t.header.nav.openSource}</a>
+        <Link href="/changelog">{t.header.nav.changelog}</Link>
         <a href={docsUrl}>{t.header.nav.docs}</a>
       </nav>
       <div className="header-actions">
@@ -358,7 +358,7 @@ export function SiteFooter({ t }: { t: Copy }) {
         <Link href="/pricing">{t.final.footerNav.pricing}</Link>
         <Link href="/profile">{t.final.footerNav.profile}</Link>
         <a href={docsUrl}>{t.final.footerNav.docs}</a>
-        <a href={releaseUrl}>{t.final.footerNav.releases}</a>
+        <Link href="/changelog">{t.final.footerNav.releases}</Link>
         <a href={repoUrl}>{t.final.footerNav.github}</a>
         <a href="mailto:hello@wesight.ai">{t.final.footerNav.contact}</a>
       </nav>

--- a/website/src/content/releaseNotes.json
+++ b/website/src/content/releaseNotes.json
@@ -1,0 +1,126 @@
+{
+  "schemaVersion": 1,
+  "windowsUnsignedNotice": "Windows x64 安装包当前尚未签名。安装时，Microsoft Defender SmartScreen 可能显示“Windows 已保护你的电脑”，请确认安装包来自 WeSight 官方 GitHub Release 后继续安装。",
+  "releases": [
+    {
+      "version": "1.0.3",
+      "date": "2026-07-29",
+      "title": "主题资源修复",
+      "summary": "修复正式安装包中的主题皮肤资源加载问题，让自定义皮肤在安装后稳定生效。",
+      "compareUrl": "https://github.com/freestylefly/wesight/compare/v1.0.2...v1.0.3",
+      "releaseUrl": "https://github.com/freestylefly/wesight/releases/tag/v1.0.3",
+      "sections": [
+        {
+          "kind": "fix",
+          "title": "修复",
+          "items": [
+            {
+              "text": "修复正式安装包中主题皮肤资源无法加载的问题",
+              "areas": ["desktop"]
+            },
+            {
+              "text": "恢复打包后自定义皮肤与主题资源的正常显示",
+              "areas": ["desktop"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "version": "1.0.2",
+      "date": "2026-07-29",
+      "title": "安装与下载体验优化",
+      "summary": "完善 Windows 下载入口与 macOS 安装界面，并增强多架构发布产物的校验稳定性。",
+      "compareUrl": "https://github.com/freestylefly/wesight/compare/v1.0.1...v1.0.2",
+      "releaseUrl": "https://github.com/freestylefly/wesight/releases/tag/v1.0.2",
+      "sections": [
+        {
+          "kind": "feature",
+          "title": "新增",
+          "items": [
+            {
+              "text": "官网新增 Windows x64 下载入口，并自动匹配最新正式安装包",
+              "areas": ["website"]
+            },
+            {
+              "text": "加入品牌化 macOS 安装界面，清晰展示应用与 Applications 文件夹",
+              "areas": ["desktop"]
+            }
+          ]
+        },
+        {
+          "kind": "fix",
+          "title": "修复",
+          "items": [
+            {
+              "text": "修复 macOS Intel 发布产物校验不稳定的问题",
+              "areas": ["release"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "version": "1.0.1",
+      "date": "2026-07-28",
+      "title": "官网与发布流程升级",
+      "summary": "官网正式并入主仓库，下载入口与三平台发布流程完成自动化。",
+      "compareUrl": "https://github.com/freestylefly/wesight/compare/v1.0.0...v1.0.1",
+      "releaseUrl": "https://github.com/freestylefly/wesight/releases/tag/v1.0.1",
+      "sections": [
+        {
+          "kind": "feature",
+          "title": "新增",
+          "items": [
+            {
+              "text": "将 WeSight 官网源码并入主仓库统一维护",
+              "areas": ["website"]
+            },
+            {
+              "text": "官网下载入口自动获取 GitHub 最新正式版安装包",
+              "areas": ["website"]
+            },
+            {
+              "text": "上线由版本标签驱动的 macOS 与 Windows 自动发布流程",
+              "areas": ["release"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "date": "2026-07-28",
+      "title": "首个纯数字正式版",
+      "summary": "WeSight 完成纯数字 SemVer 迁移，并补齐可定制皮肤与经过 Apple 签名、公证的 macOS 安装包。",
+      "compareUrl": "https://github.com/freestylefly/wesight/compare/v2026.7.16...v1.0.0",
+      "releaseUrl": "https://github.com/freestylefly/wesight/releases/tag/v1.0.0",
+      "sections": [
+        {
+          "kind": "feature",
+          "title": "新增",
+          "items": [
+            {
+              "text": "新增可定制背景皮肤，并持久化保存主题设置",
+              "areas": ["desktop"]
+            },
+            {
+              "text": "提供 Apple Silicon 与 Intel 两种经过 Apple 签名、公证的 macOS 安装包",
+              "areas": ["desktop", "release"]
+            }
+          ]
+        },
+        {
+          "kind": "improvement",
+          "title": "优化",
+          "items": [
+            {
+              "text": "加强发布产物校验、CI 检查与 OpenSquilla 侧边栏模式覆盖",
+              "areas": ["release"]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/website/src/content/releaseNotes.ts
+++ b/website/src/content/releaseNotes.ts
@@ -1,0 +1,49 @@
+import releaseNotesData from './releaseNotes.json';
+
+export const ReleaseArea = {
+  All: 'all',
+  Desktop: 'desktop',
+  Website: 'website',
+  Release: 'release',
+} as const;
+
+export type ReleaseArea = (typeof ReleaseArea)[keyof typeof ReleaseArea];
+export type ReleaseItemArea = Exclude<ReleaseArea, typeof ReleaseArea.All>;
+
+export const ReleaseSectionKind = {
+  Feature: 'feature',
+  Fix: 'fix',
+  Improvement: 'improvement',
+} as const;
+
+export type ReleaseSectionKind =
+  (typeof ReleaseSectionKind)[keyof typeof ReleaseSectionKind];
+
+export type ReleaseNoteItem = {
+  text: string;
+  areas: ReleaseItemArea[];
+};
+
+export type ReleaseNoteSection = {
+  kind: ReleaseSectionKind;
+  title: string;
+  items: ReleaseNoteItem[];
+};
+
+export type ReleaseNote = {
+  version: string;
+  date: string;
+  title: string;
+  summary: string;
+  compareUrl: string;
+  releaseUrl: string;
+  sections: ReleaseNoteSection[];
+};
+
+type ReleaseNotesDocument = {
+  schemaVersion: number;
+  windowsUnsignedNotice: string;
+  releases: ReleaseNote[];
+};
+
+export const releaseNotes = releaseNotesData as ReleaseNotesDocument;

--- a/website/src/content/siteCopy.ts
+++ b/website/src/content/siteCopy.ts
@@ -64,6 +64,7 @@ export type Copy = {
       engines: string;
       skills: string;
       openSource: string;
+      changelog: string;
       docs: string;
     };
     download: string;
@@ -130,6 +131,25 @@ export type Copy = {
     body: string;
     items: Array<{ title: string; body: string }>;
   };
+  changelog: {
+    metaTitle: string;
+    metaDescription: string;
+    eyebrow: string;
+    title: string;
+    body: string;
+    latest: string;
+    download: string;
+    githubRelease: string;
+    filterLabel: string;
+    filters: {
+      all: string;
+      desktop: string;
+      website: string;
+      release: string;
+    };
+    versionLabel: string;
+    viewRelease: string;
+  };
   final: {
     title: string;
     body: string;
@@ -165,6 +185,7 @@ export const copy: Record<Language, Copy> = {
         engines: 'Engines',
         skills: 'Skills',
         openSource: 'Open Source',
+        changelog: 'Changelog',
         docs: 'Docs',
       },
       download: 'Download',
@@ -318,6 +339,26 @@ export const copy: Record<Language, Copy> = {
         },
       ],
     },
+    changelog: {
+      metaTitle: 'WeSight Changelog - Chinese Product Updates',
+      metaDescription:
+        'Read the latest WeSight desktop, website, and release pipeline updates in Chinese.',
+      eyebrow: 'Product updates',
+      title: '更新日志',
+      body: '感谢你跟随 WeSight 一路前进。这里集中记录桌面客户端、官网与发布流程的每一次更新。',
+      latest: 'Latest',
+      download: 'Download latest',
+      githubRelease: 'GitHub Release',
+      filterLabel: 'Filter release notes',
+      filters: {
+        all: 'All updates',
+        desktop: 'Desktop',
+        website: 'Website',
+        release: 'Release pipeline',
+      },
+      versionLabel: 'WeSight',
+      viewRelease: 'View release details',
+    },
     final: {
       title: 'Download WeSight and start your desktop agent workflow',
       body: 'Get the latest desktop build from GitHub Releases, or read the source and README directly.',
@@ -352,6 +393,7 @@ export const copy: Record<Language, Copy> = {
         engines: '引擎',
         skills: '技能',
         openSource: '开源',
+        changelog: '更新日志',
         docs: '文档',
       },
       download: '下载',
@@ -493,6 +535,25 @@ export const copy: Record<Language, Copy> = {
           body: 'OpenClaw 和 Hermes runtime 由 WeSight 准备和维护。',
         },
       ],
+    },
+    changelog: {
+      metaTitle: 'WeSight 更新日志 - 产品版本记录',
+      metaDescription: '查看 WeSight 桌面客户端、官网与发布流程的中文更新日志。',
+      eyebrow: '产品动态',
+      title: '更新日志',
+      body: '感谢你跟随 WeSight 一路前进。这里集中记录桌面客户端、官网与发布流程的每一次更新。',
+      latest: '最新版本',
+      download: '下载最新版本',
+      githubRelease: 'GitHub Release',
+      filterLabel: '筛选更新日志',
+      filters: {
+        all: '全部更新',
+        desktop: '桌面客户端',
+        website: '官网',
+        release: '发布流程',
+      },
+      versionLabel: 'WeSight',
+      viewRelease: '查看发布详情',
     },
     final: {
       title: '下载 WeSight，开始你的桌面 Agent 工作流',

--- a/website/src/pages/ChangelogPage.tsx
+++ b/website/src/pages/ChangelogPage.tsx
@@ -1,0 +1,191 @@
+import {
+  ArrowUpRight,
+  CircleDot,
+  GitPullRequest,
+  Globe2,
+  Monitor,
+  PackageCheck,
+  Sparkles,
+  Wrench,
+} from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { DownloadMenu } from '../components/DownloadMenu';
+import { PageMeta } from '../components/PageMeta';
+import { RoutePage } from '../components/RoutePage';
+import {
+  ReleaseArea,
+  type ReleaseArea as ReleaseAreaValue,
+  type ReleaseNote,
+  releaseNotes,
+  type ReleaseNoteSection,
+  ReleaseSectionKind,
+} from '../content/releaseNotes';
+import { copy, type Language } from '../content/siteCopy';
+
+type ChangelogPageProps = {
+  language: Language;
+  onToggleLanguage: () => void;
+};
+
+const sectionIcons = {
+  [ReleaseSectionKind.Feature]: Sparkles,
+  [ReleaseSectionKind.Fix]: Wrench,
+  [ReleaseSectionKind.Improvement]: PackageCheck,
+};
+
+function filterRelease(release: ReleaseNote, area: ReleaseAreaValue): ReleaseNote | null {
+  if (area === ReleaseArea.All) {
+    return release;
+  }
+
+  const sections = release.sections
+    .map(section => ({
+      ...section,
+      items: section.items.filter(item => item.areas.includes(area)),
+    }))
+    .filter(section => section.items.length > 0);
+
+  return sections.length > 0 ? { ...release, sections } : null;
+}
+
+function formatReleaseDate(date: string): string {
+  return new Intl.DateTimeFormat('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date(`${date}T00:00:00`));
+}
+
+function ReleaseSection({ section }: { section: ReleaseNoteSection }) {
+  const Icon = sectionIcons[section.kind];
+
+  return (
+    <section className="release-section">
+      <h3>
+        <Icon size={18} />
+        {section.title}
+      </h3>
+      <ul>
+        {section.items.map(item => (
+          <li key={item.text}>{item.text}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export function ChangelogPage({ language, onToggleLanguage }: ChangelogPageProps) {
+  const siteCopy = copy[language];
+  const t = copy.zh.changelog;
+  const [activeArea, setActiveArea] = useState<ReleaseAreaValue>(ReleaseArea.All);
+  const latestRelease = releaseNotes.releases[0];
+  const visibleReleases = useMemo(
+    () =>
+      releaseNotes.releases
+        .map(release => filterRelease(release, activeArea))
+        .filter((release): release is ReleaseNote => release !== null),
+    [activeArea],
+  );
+  const filters = [
+    { value: ReleaseArea.All, label: t.filters.all, icon: GitPullRequest },
+    { value: ReleaseArea.Desktop, label: t.filters.desktop, icon: Monitor },
+    { value: ReleaseArea.Website, label: t.filters.website, icon: Globe2 },
+    { value: ReleaseArea.Release, label: t.filters.release, icon: PackageCheck },
+  ];
+
+  return (
+    <RoutePage language={language} onToggleLanguage={onToggleLanguage}>
+      <PageMeta
+        htmlLang="zh-CN"
+        title={t.metaTitle}
+        description={t.metaDescription}
+      />
+      <div className="changelog-frame">
+        <section className="changelog-hero">
+          <div className="changelog-heading">
+            <span className="route-eyebrow">{t.eyebrow}</span>
+            <h1>{t.title}</h1>
+            <p>{t.body}</p>
+          </div>
+          <div className="changelog-latest">
+            <span>{t.latest}</span>
+            <strong>v{latestRelease.version}</strong>
+            <time dateTime={latestRelease.date}>
+              {formatReleaseDate(latestRelease.date)}
+            </time>
+          </div>
+          <div className="changelog-actions">
+            <DownloadMenu
+              buttonClassName="primary-button"
+              copy={siteCopy.downloadMenu}
+              label={t.download}
+            />
+            <a className="secondary-button" href={latestRelease.releaseUrl}>
+              {t.githubRelease}
+              <ArrowUpRight size={17} />
+            </a>
+          </div>
+        </section>
+
+        <section className="release-log" aria-labelledby="release-log-heading">
+          <h2 className="sr-only" id="release-log-heading">
+            {t.title}
+          </h2>
+          <div
+            className="release-filters"
+            aria-label={t.filterLabel}
+            role="tablist"
+          >
+            {filters.map(filter => {
+              const Icon = filter.icon;
+              const isActive = filter.value === activeArea;
+
+              return (
+                <button
+                  key={filter.value}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  className={isActive ? 'is-active' : ''}
+                  onClick={() => setActiveArea(filter.value)}
+                >
+                  <Icon size={16} />
+                  {filter.label}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="release-list">
+            {visibleReleases.map(release => (
+              <article className="release-entry" id={`v${release.version}`} key={release.version}>
+                <div className="release-meta">
+                  <time dateTime={release.date}>{formatReleaseDate(release.date)}</time>
+                  <a href={release.releaseUrl}>
+                    <CircleDot size={13} />
+                    {t.versionLabel} {release.version}
+                  </a>
+                </div>
+                <div className="release-content">
+                  <h2>{release.title}</h2>
+                  <p>{release.summary}</p>
+                  {release.sections.map(section => (
+                    <ReleaseSection
+                      key={`${release.version}-${section.kind}-${section.title}`}
+                      section={section}
+                    />
+                  ))}
+                  <a className="release-detail-link" href={release.releaseUrl}>
+                    {t.viewRelease}
+                    <ArrowUpRight size={15} />
+                  </a>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+    </RoutePage>
+  );
+}

--- a/website/src/styles/pages.css
+++ b/website/src/styles/pages.css
@@ -197,6 +197,240 @@
   padding-bottom: 40px;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.changelog-frame {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(7, 9, 12, 0.94);
+  box-shadow: var(--shadow);
+}
+
+.changelog-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 30px 56px;
+  align-items: end;
+  padding: clamp(34px, 5vw, 56px);
+  border-bottom: 1px solid var(--line-soft);
+  background:
+    radial-gradient(circle at 88% 18%, rgba(48, 230, 207, 0.1), transparent 34%),
+    rgba(9, 11, 14, 0.94);
+}
+
+.changelog-heading {
+  min-width: 0;
+}
+
+.changelog-heading h1 {
+  margin: 22px 0 0;
+  font-size: clamp(42px, 6vw, 64px);
+  line-height: 1;
+  letter-spacing: -0.045em;
+}
+
+.changelog-heading p {
+  width: min(720px, 100%);
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 16px;
+  line-height: 1.75;
+}
+
+.changelog-latest {
+  display: grid;
+  min-width: 164px;
+  gap: 7px;
+  justify-items: end;
+  padding: 18px 20px;
+  border: 1px solid var(--line-soft);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.changelog-latest span {
+  color: var(--teal);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.changelog-latest strong {
+  font-size: 24px;
+  letter-spacing: -0.02em;
+}
+
+.changelog-latest time {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.changelog-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  grid-column: 1 / -1;
+}
+
+.release-log {
+  padding: 0 clamp(28px, 5vw, 56px);
+}
+
+.release-filters {
+  display: flex;
+  gap: 12px;
+  padding: 20px 0;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--line-soft);
+  scrollbar-width: none;
+}
+
+.release-filters::-webkit-scrollbar {
+  display: none;
+}
+
+.release-filters button {
+  display: inline-flex;
+  min-height: 36px;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+  padding: 0 13px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.release-filters button:hover {
+  color: var(--muted-strong);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.release-filters button.is-active {
+  border-color: var(--line);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+}
+
+.release-filters button.is-active svg {
+  color: var(--teal);
+}
+
+.release-list {
+  display: grid;
+}
+
+.release-entry {
+  display: grid;
+  grid-template-columns: minmax(150px, 190px) minmax(0, 1fr);
+  gap: clamp(32px, 6vw, 74px);
+  padding: 48px 0 54px;
+}
+
+.release-entry + .release-entry {
+  border-top: 1px solid var(--line-soft);
+}
+
+.release-meta {
+  display: grid;
+  align-content: start;
+  gap: 13px;
+}
+
+.release-meta time {
+  color: var(--muted-strong);
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.release-meta a {
+  display: inline-flex;
+  width: max-content;
+  max-width: 100%;
+  min-height: 28px;
+  align-items: center;
+  gap: 7px;
+  padding: 0 9px;
+  border: 1px solid rgba(48, 230, 207, 0.14);
+  border-radius: 6px;
+  background: rgba(48, 230, 207, 0.08);
+  color: var(--teal);
+  font-size: 11px;
+  font-weight: 760;
+}
+
+.release-content h2 {
+  margin: 0;
+  font-size: clamp(24px, 3vw, 30px);
+  line-height: 1.18;
+  letter-spacing: -0.025em;
+}
+
+.release-content > p {
+  width: min(760px, 100%);
+  margin: 14px 0 0;
+  color: var(--muted-strong);
+  font-size: 15px;
+  line-height: 1.75;
+}
+
+.release-section {
+  margin-top: 24px;
+}
+
+.release-section h3 {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin: 0;
+  color: var(--text);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.release-section h3 svg {
+  color: var(--teal);
+}
+
+.release-section ul {
+  display: grid;
+  gap: 7px;
+  margin: 12px 0 0;
+  padding-left: 20px;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.release-detail-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 26px;
+  color: var(--teal);
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.release-detail-link:hover {
+  color: var(--text);
+}
+
 @media (max-width: 760px) {
   .route-page {
     width: calc(100% - 36px);
@@ -235,5 +469,43 @@
   .guide-heading,
   .notice-panel {
     flex-direction: column;
+  }
+
+  .changelog-hero {
+    grid-template-columns: 1fr;
+    gap: 24px;
+    padding: 28px 22px;
+  }
+
+  .changelog-heading h1 {
+    font-size: 42px;
+  }
+
+  .changelog-latest {
+    width: 100%;
+    justify-items: start;
+  }
+
+  .changelog-actions {
+    grid-column: auto;
+  }
+
+  .changelog-actions .download-menu,
+  .changelog-actions .secondary-button {
+    width: 100%;
+  }
+
+  .release-log {
+    padding: 0 22px;
+  }
+
+  .release-entry {
+    grid-template-columns: 1fr;
+    gap: 24px;
+    padding: 34px 0 40px;
+  }
+
+  .release-meta {
+    gap: 10px;
   }
 }

--- a/website/src/styles/site.css
+++ b/website/src/styles/site.css
@@ -146,7 +146,7 @@ section,
   min-width: 0;
   align-items: center;
   justify-content: center;
-  gap: 24px;
+  gap: 20px;
   color: var(--muted-strong);
   font-size: 13px;
   font-weight: 680;


### PR DESCRIPTION
## Summary

- add a responsive Chinese changelog page with release-area filters
- centralize release notes for the website and GitHub Release workflow
- require prepared Chinese notes before creating release tags
- clean GitHub Markdown before showing release notes in the desktop update modal

## Why

The website, GitHub Releases, and the desktop updater should present one consistent Chinese changelog sourced from a single maintained data file.

## Validation

- `npm test -- appUpdate render-release-notes release-version` (28 tests)
- `npm run build --prefix website` (7 tests and production build)
- `npm run build`
- targeted ESLint checks
- desktop and mobile browser QA with filter and download-menu interaction checks
