### PR TITLE
fix(docs): restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Scan the QR code below to join the WeSight WeChat group and talk with other buil
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=freestylefly/wesight&type=Date)](https://star-history.com/#freestylefly/wesight&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=freestylefly/wesight&type=Date)](https://star-history.dera.page/#freestylefly/wesight&Date)
 
 ## WeChat Official Account
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -345,7 +345,7 @@ WeSight 内置了一组覆盖日常 Agent 工作的技能，并接入 SkillHub �
 
 ## Star 趋势图
 
-[![Star History Chart](https://api.star-history.com/svg?repos=freestylefly/wesight&type=Date)](https://star-history.com/#freestylefly/wesight&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=freestylefly/wesight&type=Date)](https://star-history.dera.page/#freestylefly/wesight&Date)
 
 ## 公众号
 


### PR DESCRIPTION
The current star history chart is broken because of GitHub stargazer API restrictions. This PR repoints the chart image and its link to the star-history.dera.page mirror, which uses an alternative data source that requires no API token, so the chart renders correctly again.