### PR TITLE
fix(claude): stop restoring stale local env after external provider switch

### DIFF
--- a/src/main/libs/externalAgentConfigSync.test.ts
+++ b/src/main/libs/externalAgentConfigSync.test.ts
@@ -402,6 +402,100 @@ test('mergeClaudeSettingsForWesightModel preserves the earliest original env sna
   });
 });
 
+test('mergeClaudeSettingsForWesightModel records the managed overlay env', () => {
+  const merged = mergeClaudeSettingsForWesightModel({}, apiConfig);
+  const managed = (merged.__wesight_managed as Record<string, unknown>).claudeCode as Record<string, unknown>;
+
+  expect(managed.managedEnv).toEqual({
+    ANTHROPIC_AUTH_TOKEN: apiConfig.apiKey,
+    ANTHROPIC_BASE_URL: apiConfig.baseURL,
+    ANTHROPIC_MODEL: apiConfig.model,
+    ANTHROPIC_REASONING_MODEL: apiConfig.model,
+    ANTHROPIC_DEFAULT_SONNET_MODEL: apiConfig.model,
+    ANTHROPIC_DEFAULT_OPUS_MODEL: apiConfig.model,
+    ANTHROPIC_DEFAULT_HAIKU_MODEL: apiConfig.model,
+    ANTHROPIC_SMALL_FAST_MODEL: apiConfig.model,
+  });
+});
+
+const externallySwitchedEnv = {
+  ANTHROPIC_AUTH_TOKEN: 'sk-local-b',
+  ANTHROPIC_BASE_URL: 'https://local-b.example/v1',
+  ANTHROPIC_MODEL: 'model-b',
+  ANTHROPIC_REASONING_MODEL: 'model-b',
+  ANTHROPIC_DEFAULT_SONNET_MODEL: 'model-b',
+  ANTHROPIC_DEFAULT_OPUS_MODEL: 'model-b',
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: 'model-b',
+  ANTHROPIC_SMALL_FAST_MODEL: 'model-b',
+};
+
+test('removeWesightManagedClaudeSettings keeps an externally switched local env instead of restoring a stale snapshot', () => {
+  const merged = mergeClaudeSettingsForWesightModel({
+    env: {
+      ANTHROPIC_BASE_URL: 'https://local-a.example/v1',
+      ANTHROPIC_MODEL: 'model-a',
+    },
+  }, apiConfig);
+  // An external tool (or the user) switches the local provider while WeSight
+  // metadata is present, e.g. by rewriting settings.json wholesale.
+  const externallySwitched = {
+    ...merged,
+    env: { ...externallySwitchedEnv },
+  };
+
+  const cleaned = removeWesightManagedClaudeSettings(externallySwitched);
+
+  expect(cleaned.__wesight_managed).toBeUndefined();
+  expect(cleaned.env).toEqual(externallySwitchedEnv);
+});
+
+test('mergeClaudeSettingsForWesightModel refreshes a stale snapshot after an external local env change', () => {
+  const merged = mergeClaudeSettingsForWesightModel({
+    env: {
+      ANTHROPIC_BASE_URL: 'https://local-a.example/v1',
+      ANTHROPIC_MODEL: 'model-a',
+    },
+  }, apiConfig);
+  const externallySwitched = {
+    ...merged,
+    env: { ...externallySwitchedEnv },
+  };
+
+  const remerged = mergeClaudeSettingsForWesightModel(externallySwitched, apiConfig);
+  const runtimeEnv = remerged.env as Record<string, unknown>;
+  expect(runtimeEnv.ANTHROPIC_BASE_URL).toBe(apiConfig.baseURL);
+  expect(runtimeEnv.ANTHROPIC_MODEL).toBe(apiConfig.model);
+
+  const cleaned = removeWesightManagedClaudeSettings(remerged);
+  expect(cleaned.env).toEqual(externallySwitchedEnv);
+});
+
+test('removeWesightManagedClaudeSettings restores the snapshot for legacy metadata without managedEnv', () => {
+  const legacy = {
+    env: {
+      ANTHROPIC_BASE_URL: 'https://wesight-overlay.example/v1',
+      ANTHROPIC_MODEL: 'wesight-overlay-model',
+    },
+    __wesight_managed: {
+      claudeCode: {
+        envKeys: ['ANTHROPIC_BASE_URL', 'ANTHROPIC_MODEL'],
+        originalEnv: {
+          ANTHROPIC_BASE_URL: 'https://local.example/v1',
+          ANTHROPIC_MODEL: 'local-claude',
+        },
+      },
+    },
+  };
+
+  const cleaned = removeWesightManagedClaudeSettings(legacy);
+
+  expect(cleaned.__wesight_managed).toBeUndefined();
+  expect(cleaned.env).toEqual({
+    ANTHROPIC_BASE_URL: 'https://local.example/v1',
+    ANTHROPIC_MODEL: 'local-claude',
+  });
+});
+
 test('cleanupWesightManagedClaudeSettings restores settings on disk', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wesight-claude-settings-'));
   const settingsPath = path.join(tempDir, 'settings.json');

--- a/src/main/libs/externalAgentConfigSync.ts
+++ b/src/main/libs/externalAgentConfigSync.ts
@@ -697,6 +697,17 @@ const buildClaudeEnvForConfig = (
   };
 };
 
+const getOwnValue = (record: Record<string, unknown>, key: string): unknown => (
+  Object.prototype.hasOwnProperty.call(record, key) ? record[key] : undefined
+);
+
+const claudeEnvMatchesManagedOverlay = (
+  env: Record<string, unknown>,
+  managedEnv: Record<string, unknown>,
+): boolean => CLAUDE_MANAGED_ENV_KEYS.every(
+  (key) => getOwnValue(env, key) === getOwnValue(managedEnv, key),
+);
+
 export const mergeClaudeSettingsForWesightModel = (
   existingSettings: Record<string, unknown>,
   config: CoworkApiConfig,
@@ -707,10 +718,16 @@ export const mergeClaudeSettingsForWesightModel = (
   const previousEnvKeys = getStringArray(existingClaude.envKeys);
   const previousCreatedEnvKeys = getStringArray(existingClaude.createdEnvKeys);
   const previousOriginalEnv = getNestedRecord(existingClaude, 'originalEnv');
+  const previousManagedEnv = getNestedRecord(existingClaude, 'managedEnv');
   const hasRecoverableSnapshot = Object.keys(previousOriginalEnv).length > 0 || previousCreatedEnvKeys.length > 0;
   const baselineEnv = { ...getNestedRecord(existingSettings, 'env') };
+  // When the live env no longer matches the overlay WeSight last wrote, an
+  // external tool (or the user) changed the local config; the stored snapshot
+  // is stale and must be refreshed from the live env instead of restored.
+  const overlayModifiedExternally = Object.keys(previousManagedEnv).length > 0
+    && !claudeEnvMatchesManagedOverlay(baselineEnv, previousManagedEnv);
 
-  if (hasRecoverableSnapshot) {
+  if (hasRecoverableSnapshot && !overlayModifiedExternally) {
     for (const key of previousEnvKeys) {
       if (Object.prototype.hasOwnProperty.call(previousOriginalEnv, key)) {
         baselineEnv[key] = previousOriginalEnv[key];
@@ -731,11 +748,14 @@ export const mergeClaudeSettingsForWesightModel = (
   const createdEnvKeys = new Set(previousCreatedEnvKeys);
   for (const key of CLAUDE_MANAGED_ENV_KEYS) {
     if (Object.prototype.hasOwnProperty.call(baselineEnv, key)) {
-      if (!Object.prototype.hasOwnProperty.call(originalEnv, key)) {
+      if (overlayModifiedExternally || !Object.prototype.hasOwnProperty.call(originalEnv, key)) {
         originalEnv[key] = baselineEnv[key];
       }
       createdEnvKeys.delete(key);
     } else {
+      if (overlayModifiedExternally) {
+        delete originalEnv[key];
+      }
       createdEnvKeys.add(key);
     }
   }
@@ -743,6 +763,11 @@ export const mergeClaudeSettingsForWesightModel = (
   const credentialKey = chooseClaudeCredentialEnvKey(baselineEnv, options.credentialKey);
   const env = buildClaudeEnvForConfig(baselineEnv, config, credentialKey);
   const envKeys = [...CLAUDE_MANAGED_ENV_KEYS];
+  const managedEnv = Object.fromEntries(
+    envKeys
+      .filter((key) => Object.prototype.hasOwnProperty.call(env, key))
+      .map((key) => [key, env[key]]),
+  );
   return {
     ...existingSettings,
     env,
@@ -753,6 +778,7 @@ export const mergeClaudeSettingsForWesightModel = (
         envKeys,
         createdEnvKeys: envKeys.filter((key) => createdEnvKeys.has(key)),
         originalEnv,
+        managedEnv,
         credentialKey,
       },
     },
@@ -769,6 +795,7 @@ const removeClaudeManagedMetadata = (
   delete claudeManaged.envKeys;
   delete claudeManaged.createdEnvKeys;
   delete claudeManaged.originalEnv;
+  delete claudeManaged.managedEnv;
   delete claudeManaged.credentialKey;
 
   const managed = { ...existingManaged };
@@ -814,6 +841,15 @@ export const removeWesightManagedClaudeSettings = (
   }
 
   const env = { ...getNestedRecord(existingSettings, 'env') };
+  const previousManagedEnv = getNestedRecord(existingClaude, 'managedEnv');
+  if (
+    Object.keys(previousManagedEnv).length > 0
+    && !claudeEnvMatchesManagedOverlay(env, previousManagedEnv)
+  ) {
+    // The local env was changed externally after WeSight applied its overlay;
+    // keep the user's current values instead of restoring the stale snapshot.
+    return removeClaudeManagedMetadata(existingSettings, existingManaged, existingClaude, env);
+  }
   for (const key of previousEnvKeys) {
     if (Object.prototype.hasOwnProperty.call(previousOriginalEnv, key)) {
       env[key] = previousOriginalEnv[key];


### PR DESCRIPTION
## Summary
- The `__wesight_managed.claudeCode.originalEnv` snapshot in `~/.claude/settings.json` is captured once (\"first seen wins\") and never updated.
- When the local Claude Code provider is changed outside WeSight — e.g. by a config switcher (cc-switch) that rewrites `settings.json` while preserving the `__wesight_managed` block — restarting WeSight or switching the config source to \"local CLI config\" (本机配置) restores the **outdated snapshot**, silently reverting the user's provider/model to a previously used one.
- Fix: record the overlay env WeSight last wrote as `managedEnv` in the managed metadata. On merge/cleanup, if the live env no longer matches that overlay, treat it as an external change: keep the live values and refresh the snapshot instead of restoring the stale one. Legacy metadata without `managedEnv` keeps the previous behavior.

## Reproduction
1. Configure a local Claude Code provider A (e.g. via a config switcher), let WeSight manage settings once (WeSight model mode), then switch back to local config — snapshot now contains A.
2. Switch the local provider to B outside WeSight (config switcher rewrites `settings.json`, preserving `__wesight_managed` with snapshot A).
3. Restart WeSight with config source = local CLI config → `removeWesightManagedClaudeSettings` restores provider A into `env`; the UI and launched Claude Code use A instead of B.

## Test plan
- [x] `npx vitest run src/main/libs/externalAgentConfigSync.test.ts` — 27/27 pass (4 new cases: managedEnv recording, external switch preserved on cleanup, snapshot refresh on next merge, legacy metadata backward compatibility)
- [x] Full `npx vitest run` — no new failures (1 pre-existing environment-dependent failure in `externalAgentEnvironment.test.ts`, also fails on clean `main`)
- [x] `npx tsc --noEmit` clean; `npx eslint` on changed files clean
- [ ] Manual: switch local provider via an external tool, restart WeSight with 本机配置, verify the current provider is kept